### PR TITLE
ananicy-cpp: Package cachyos-ananicy-rules in a separate package

### DIFF
--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -8,7 +8,7 @@
 %define _disable_source_fetch 0
 
 Name:           ananicy-cpp
-Release:        8%{?dist}
+Release:        9%{?dist}
 Version:	    1.1.1
 Summary:        Rewrite of ananicy in c++ for lower cpu and memory usage
 License:        GPLv3
@@ -34,16 +34,9 @@ Requires:	ananicy-cpp-rules
 %description
 Rewrite of ananicy in c++ for lower cpu and memory usage
 
-%package rules
-Summary: list of rules used to assign specific nice values to specific processes.
-Requires: ananicy-cpp
-%description rules
-list of rules used to assign specific nice values to specific processes.
-
 
 %prep
 %autosetup -n ananicy-cpp-v%{version}
-git clone https://github.com/CachyOS/ananicy-rules.git %{_builddir}/ananicy-cpp-rules 
 
 %build
 %cmake \
@@ -58,12 +51,6 @@ git clone https://github.com/CachyOS/ananicy-rules.git %{_builddir}/ananicy-cpp-
 
 %install
 %ninja_install -C %{_vpath_builddir}
-
-mkdir -p %{buildroot}/etc/ananicy.d/00-default
-cp %{_builddir}/ananicy-cpp-rules/00-default %{buildroot}/etc/ananicy.d/ -r
-cp %{_builddir}/ananicy-cpp-rules/00-cgroups.cgroups %{buildroot}/etc/ananicy.d/ -r
-cp %{_builddir}/ananicy-cpp-rules/00-types.types %{buildroot}/etc/ananicy.d/ -r
-cp %{_builddir}/ananicy-cpp-rules/ananicy.conf %{buildroot}/etc/ananicy.d/ -r
 
 
 
@@ -83,12 +70,6 @@ systemctl disable --now ananicy-cpp
 %doc README.md
 %{_bindir}/ananicy-cpp
 %{_unitdir}/ananicy-cpp.service
-
-%files rules
-%defattr(-,root,root,-)
-/etc/ananicy.d/*
-
-
 
 %changelog
 %autochangelog/*

--- a/sources/ananicy-cpp/cachyos-ananicy-rules.spec
+++ b/sources/ananicy-cpp/cachyos-ananicy-rules.spec
@@ -1,10 +1,10 @@
-%global commit c6153c9e909475bbb08b4e56af152179ff7f171f
+%global commit 564e1a471bd6ebaec6c1a7bd838dc6e592e73104
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %define _disable_source_fetch 0
 
 Name:           cachyos-ananicy-rules
-Version:        20240727.r%{shortcommit}
+Version:        20240825.r%{shortcommit}
 Release:        1%{?dist}
 Summary:        List of rules used to assign specific nice values to specific processes
 

--- a/sources/ananicy-cpp/cachyos-ananicy-rules.spec
+++ b/sources/ananicy-cpp/cachyos-ananicy-rules.spec
@@ -1,0 +1,40 @@
+%global commit c6153c9e909475bbb08b4e56af152179ff7f171f
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%define _disable_source_fetch 0
+
+Name:           cachyos-ananicy-rules
+Version:        20240727.r%{shortcommit}
+Release:        1%{?dist}
+Summary:        List of rules used to assign specific nice values to specific processes
+
+License:        GPL=3.0
+URL:            https://github.com/CachyOS/ananicy-rules
+Source0:        %{URL}/archive/%{commit}/ananicy-rules-%{commit}.tar.gz
+
+Requires: ananicy-cpp
+Obsoletes: ananicy-cpp-rules < %{version}-%{release}
+Provides:  ananicy-cpp-rules = %{version}-%{release}
+
+%define __spec_install_post /usr/lib/rpm/brp-compress || :
+%define debug_package %{nil}
+
+%description
+List of rules used to assign specific nice values to specific processes
+
+%prep
+%autosetup -n ananicy-rules-%{commit}
+
+%install
+install -d %{buildroot}/etc/ananicy.d
+cp %{_builddir}/ananicy-rules-%{commit}/00-default %{buildroot}/etc/ananicy.d/ -r
+cp %{_builddir}/ananicy-rules-%{commit}/00-cgroups.cgroups %{buildroot}/etc/ananicy.d/ -r
+cp %{_builddir}/ananicy-rules-%{commit}/00-types.types %{buildroot}/etc/ananicy.d/ -r
+cp %{_builddir}/ananicy-rules-%{commit}/ananicy.conf %{buildroot}/etc/ananicy.d/ -r
+
+%files
+%defattr(-,root,root,-)
+/etc/ananicy.d/*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Packaging the rules in a separate package enables us to utilize copr's autobuilds with minimal risk. It also prevents the need to rebuild ananicy-cpp everytime we want to update the rules we provide. This way, users can update the rules in their system without the need to update ananicy-cpp itself.

I have also opted to change the package name to match the PKGBUILD. There is no need for manual user intervention because everything is handled in the .spec file.

New builds are up in the [development](https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos-dev/builds) repo