### PR TITLE
kernel-cachyos/bore: Restore base time slice to 2ms

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -312,7 +312,7 @@ scripts/config -u LOCALVERSION
 scripts/config -e CACHY
 
 # Enable BORE Scheduler
-scripts/config -e SCHED_BORE --set-val MIN_BASE_SLICE_NS 1000000
+scripts/config -e SCHED_BORE
 
 %if %{llvm_kbuild} && 0%{?fedora} == 41
 # Disable debug on LTO + Fedora 41

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -312,7 +312,7 @@ scripts/config -u LOCALVERSION
 scripts/config -e CACHY
 
 # Enable BORE Scheduler
-scripts/config -e SCHED_BORE --set-val MIN_BASE_SLICE_NS 1000000
+scripts/config -e SCHED_BORE
 
 %if %{llvm_kbuild} && 0%{?fedora} == 41
 # Disable debug on LTO + Fedora 41


### PR DESCRIPTION
See https://github.com/CachyOS/linux-cachyos/pull/305 for details.

To be merged if/when the upstream PR is merged.