### PR TITLE
feat: Refactor ananicy-cpp spec

### DIFF
--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -56,12 +56,10 @@ Rewrite of ananicy in c++ for lower cpu and memory usage
     -GNinja \
     -DENABLE_SYSTEMD=ON \
     -DUSE_BPF_PROC_IMPL=ON \
+    -DBPF_BUILD_LIBBPF=OFF \
     -DUSE_EXTERNAL_FMTLIB=ON \
     -DUSE_EXTERNAL_JSON=ON \
     -DUSE_EXTERNAL_SPDLOG=ON \
-    -DBPF_BUILD_LIBBPF=OFF \
-    -DENABLE_ANANICY_TESTS=ON \
-    -DBUILD_SHARED_LIBS=OFF \
     -DVERSION=%{version}
 %cmake_build --target %{name}
 

--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -8,7 +8,7 @@
 %define _disable_source_fetch 0
 
 Name:           ananicy-cpp
-Release:        9%{?dist}
+Release:        10%{?dist}
 Version:	    1.1.1
 Summary:        Rewrite of ananicy in c++ for lower cpu and memory usage
 License:        GPLv3
@@ -27,7 +27,6 @@ BuildRequires:  ninja-build
 BuildRequires:  spdlog-devel
 BuildRequires:  systemd-devel
 
-Requires:	ananicy-cpp-rules
 Requires:       elfutils-libelf
 Requires:       fmt
 Requires:       gcc-libs
@@ -37,6 +36,8 @@ Requires:       spdlog
 Requires:       systemd
 Requires:       systemd-libs
 Requires:       zlib-ng-compat
+
+Recommends:     cachyos-ananicy-rules
 
 
 %description

--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -17,32 +17,27 @@ Source0:        %{url}/-/archive/v%{version}/ananicy-cpp-v%{version}.tar.gz
 
 ExcludeArch:    s390x i686 ppc64le
 
-BuildRequires:  gcc-c++
-BuildRequires:  cmake
-BuildRequires:  ninja-build
-BuildRequires:  systemd-devel
-BuildRequires:  systemd-rpm-macros
-BuildRequires:  zlib-devel
-BuildRequires:  git
 BuildRequires:  bpftool
-BuildRequires:  libbpf-devel
-BuildRequires:  elfutils-libelf
-BuildRequires:  llvm
 BuildRequires:  clang
+BuildRequires:  cmake
 BuildRequires:  fmt-devel
-BuildRequires:  spdlog-devel
 BuildRequires:  json-devel
+BuildRequires:  libbpf-devel
+BuildRequires:  ninja-build
+BuildRequires:  spdlog-devel
+BuildRequires:  systemd-devel
 
 Requires:	ananicy-cpp-rules
+Requires:       elfutils-libelf
+Requires:       fmt
+Requires:       gcc-libs
+Requires:       glibc
 Requires:       libbpf
+Requires:       spdlog
 Requires:       systemd
 Requires:       systemd-libs
 Requires:       zlib-ng-compat
-Requires:       gcc-libs
-Requires:       glibc
-Requires:       fmt
-Requires:       spdlog
-Requires:       elfutils-libelf
+
 
 %description
 Rewrite of ananicy in c++ for lower cpu and memory usage

--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -29,9 +29,20 @@ BuildRequires:  libbpf-devel
 BuildRequires:  elfutils-libelf
 BuildRequires:  llvm
 BuildRequires:  clang
+BuildRequires:  fmt-devel
+BuildRequires:  spdlog-devel
+BuildRequires:  json-devel
 
 Requires:	ananicy-cpp-rules
-Requires: libbpf
+Requires:       libbpf
+Requires:       systemd
+Requires:       systemd-libs
+Requires:       zlib-ng-compat
+Requires:       gcc-libs
+Requires:       glibc
+Requires:       fmt
+Requires:       spdlog
+Requires:       elfutils-libelf
 
 %description
 Rewrite of ananicy in c++ for lower cpu and memory usage
@@ -45,6 +56,9 @@ Rewrite of ananicy in c++ for lower cpu and memory usage
     -GNinja \
     -DENABLE_SYSTEMD=ON \
     -DUSE_BPF_PROC_IMPL=ON \
+    -DUSE_EXTERNAL_FMTLIB=ON \
+    -DUSE_EXTERNAL_JSON=ON \
+    -DUSE_EXTERNAL_SPDLOG=ON \
     -DBPF_BUILD_LIBBPF=OFF \
     -DENABLE_ANANICY_TESTS=ON \
     -DBUILD_SHARED_LIBS=OFF \

--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -29,7 +29,9 @@ BuildRequires:  libbpf-devel
 BuildRequires:  elfutils-libelf
 BuildRequires:  llvm
 BuildRequires:  clang
+
 Requires:	ananicy-cpp-rules
+Requires: libbpf
 
 %description
 Rewrite of ananicy in c++ for lower cpu and memory usage
@@ -42,7 +44,7 @@ Rewrite of ananicy in c++ for lower cpu and memory usage
 %cmake \
     -GNinja \
     -DENABLE_SYSTEMD=ON \
-    -DUSE_BPF_PROC_IMPL=OFF \
+    -DUSE_BPF_PROC_IMPL=ON \
     -DBPF_BUILD_LIBBPF=OFF \
     -DENABLE_ANANICY_TESTS=ON \
     -DBUILD_SHARED_LIBS=OFF \

--- a/sources/ananicy-cpp/ananicy-cpp.spec
+++ b/sources/ananicy-cpp/ananicy-cpp.spec
@@ -63,16 +63,10 @@ Rewrite of ananicy in c++ for lower cpu and memory usage
     -DENABLE_ANANICY_TESTS=ON \
     -DBUILD_SHARED_LIBS=OFF \
     -DVERSION=%{version}
-%ninja_build -C %{_vpath_builddir}
+%cmake_build --target %{name}
 
 %install
-%ninja_install -C %{_vpath_builddir}
-
-
-
-%check
-./%{_vpath_builddir}/src/tests/test-core
-./%{_vpath_builddir}/src/tests/test-utility --test-case-exclude="Process Info"
+%cmake_install --component Runtime
 
 %posttrans
 systemctl enable --now ananicy-cpp


### PR DESCRIPTION
Notable changes:
- Use the bpf backend instead of the netlink backend, this addresses [ananicy-cpp/#33](https://gitlab.com/ananicy-cpp/ananicy-cpp/-/issues/33)
- Dynamically link dependencies instead of statically linking them (known offenders are fmt, spdlog and json)
- Use cmake to build and install files instead of ninja
- Make the rules package a weakdep instead