### PR TITLE
Patch kernel for Nvidia 560

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -78,8 +78,8 @@ Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-ca
 Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
 # Stable patches
 Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/copr-linux-cachyos/%{_git_branch}/sources/kernel-patches/revert-nvidia-446d0f48.patch
-Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
+Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
+Patch2: https://raw.githubusercontent.com/CachyOS/copr-linux-cachyos/%{_git_branch}/sources/kernel-patches/revert-nvidia-446d0f48.patch
 
 %if "%{_nv_ver}" == "560.35.03"
 Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled-560.patch
@@ -293,10 +293,13 @@ tar -xzf %{SOURCE2} -C %{_builddir}
 # Apply CachyOS patch
 patch -p1 -i %{PATCH0}
 
+# Apply EEVDF and BORE patches
 patch -p1 -i %{PATCH1}
 
-# Apply EEVDF and BORE patches
+# Apply patch to the kernel to make compilation of Nvidia closed source driver 560 compile successfully
+%if "%{_nv_ver}" == "560.35.03"
 patch -p1 -i %{PATCH2}
+%endif
 
 ### Apply patches for nvidia-open
 # Set modeset and fbdev to default enabled

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -23,7 +23,7 @@
 %endif
 
 # define git branch to make testing easier without merging to master branch
-%define _git_branch master
+%define _git_branch revert-nvidia-446d0f48
 
 # whether to build kernel with llvm compiler(clang)
 %define llvm_kbuild 1
@@ -46,7 +46,7 @@ Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
 
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver cb%{customver}
 
 Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
@@ -78,6 +78,7 @@ Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-ca
 Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
 # Stable patches
 Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
+Patch1: https://raw.githubusercontent.com/CachyOS/copr-linux-cachyos/%{_git_branch}/sources/kernel-patches/revert-nvidia-446d0f48.patch
 Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
 
 %if "%{_nv_ver}" == "560.35.03"
@@ -291,6 +292,8 @@ tar -xzf %{SOURCE2} -C %{_builddir}
 
 # Apply CachyOS patch
 patch -p1 -i %{PATCH0}
+
+patch -p1 -i %{PATCH1}
 
 # Apply EEVDF and BORE patches
 patch -p1 -i %{PATCH2}

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -78,8 +78,8 @@ Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-ca
 Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
 # Stable patches
 Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/copr-linux-cachyos/%{_git_branch}/sources/kernel-patches/revert-nvidia-446d0f48.patch
-Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
+Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
+Patch2: https://raw.githubusercontent.com/CachyOS/copr-linux-cachyos/%{_git_branch}/sources/kernel-patches/revert-nvidia-446d0f48.patch
 
 %if "%{_nv_ver}" == "560.35.03"
 Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled-560.patch
@@ -293,10 +293,13 @@ tar -xzf %{SOURCE2} -C %{_builddir}
 # Apply CachyOS patch
 patch -p1 -i %{PATCH0}
 
+# Apply EEVDF and BORE patches
 patch -p1 -i %{PATCH1}
 
-# Apply EEVDF and BORE patches
+# Apply patch to the kernel to make compilation of Nvidia closed source driver 560 compile successfully
+%if "%{_nv_ver}" == "560.35.03"
 patch -p1 -i %{PATCH2}
+%endif
 
 ### Apply patches for nvidia-open
 # Set modeset and fbdev to default enabled

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -23,7 +23,7 @@
 %endif
 
 # define git branch to make testing easier without merging to master branch
-%define _git_branch master
+%define _git_branch revert-nvidia-446d0f48
 
 # whether to build kernel with llvm compiler(clang)
 %define llvm_kbuild 0
@@ -46,7 +46,7 @@ Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
 
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver cb%{customver}
 
 Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
@@ -78,6 +78,7 @@ Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-ca
 Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
 # Stable patches
 Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
+Patch1: https://raw.githubusercontent.com/CachyOS/copr-linux-cachyos/%{_git_branch}/sources/kernel-patches/revert-nvidia-446d0f48.patch
 Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
 
 %if "%{_nv_ver}" == "560.35.03"
@@ -291,6 +292,8 @@ tar -xzf %{SOURCE2} -C %{_builddir}
 
 # Apply CachyOS patch
 patch -p1 -i %{PATCH0}
+
+patch -p1 -i %{PATCH1}
 
 # Apply EEVDF and BORE patches
 patch -p1 -i %{PATCH2}

--- a/sources/kernel-patches/revert-nvidia-446d0f48.patch
+++ b/sources/kernel-patches/revert-nvidia-446d0f48.patch
@@ -1,0 +1,60 @@
+--- b/drivers/gpu/drm/drm_probe_helper.c
++++ a/drivers/gpu/drm/drm_probe_helper.c
+@@ -714,7 +714,7 @@
+  * @dev: drm_device whose connector state changed
+  *
+  * This function fires off the uevent for userspace and also calls the
++ * output_poll_changed function, which is most commonly used to inform the fbdev
+- * client hotplug function, which is most commonly used to inform the fbdev
+  * emulation code and allow it to update the fbcon output configuration.
+  *
+  * Drivers should call this from their hotplug handling code when a change is
+@@ -730,7 +730,11 @@
+  */
+ void drm_kms_helper_hotplug_event(struct drm_device *dev)
+ {
++	/* send a uevent + call fbdev */
+ 	drm_sysfs_hotplug_event(dev);
++	if (dev->mode_config.funcs->output_poll_changed)
++		dev->mode_config.funcs->output_poll_changed(dev);
++
+ 	drm_client_dev_hotplug(dev);
+ }
+ EXPORT_SYMBOL(drm_kms_helper_hotplug_event);
+@@ -746,7 +750,11 @@
+ {
+ 	struct drm_device *dev = connector->dev;
+ 
++	/* send a uevent + call fbdev */
+ 	drm_sysfs_connector_hotplug_event(connector);
++	if (dev->mode_config.funcs->output_poll_changed)
++		dev->mode_config.funcs->output_poll_changed(dev);
++
+ 	drm_client_dev_hotplug(dev);
+ }
+ EXPORT_SYMBOL(drm_kms_helper_connector_hotplug_event);
+--- b/include/drm/drm_mode_config.h
++++ a/include/drm/drm_mode_config.h
+@@ -97,6 +97,22 @@
+ 	 */
+ 	const struct drm_format_info *(*get_format_info)(const struct drm_mode_fb_cmd2 *mode_cmd);
+ 
++	/**
++	 * @output_poll_changed:
++	 *
++	 * Callback used by helpers to inform the driver of output configuration
++	 * changes.
++	 *
++	 * Drivers implementing fbdev emulation use drm_kms_helper_hotplug_event()
++	 * to call this hook to inform the fbdev helper of output changes.
++	 *
++	 * This hook is deprecated, drivers should instead implement fbdev
++	 * support with struct drm_client, which takes care of any necessary
++	 * hotplug event forwarding already without further involvement by
++	 * the driver.
++	 */
++	void (*output_poll_changed)(struct drm_device *dev);
++
+ 	/**
+ 	 * @mode_valid:
+ 	 *


### PR DESCRIPTION
Because some functions were removed in 6.12, the closed source Nvidia 560 driver fails to build.
This patch adds back these functions and makes it possible to build the driver.

If/when RPMfusion will patch the driver, this patch can be removed.

The patch will only be applied on Fedora version which uses the 560 driver (f39 and f40)