### PR TITLE
feat: Kernel rpmbuild Spec Rewrite

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -11,8 +11,8 @@
 %undefine _include_frame_pointers
 
 # Linux Kernel Versions
-%define _basekver 6.12
-%define _stablekver 10
+%define _basekver 6.13
+%define _stablekver 0
 %define _rpmver %{version}-%{release}
 %define _kver %{_rpmver}.%{_arch}
 
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos4%{?_lto_args:.lto}%{?dist}
+Release:        cachyos1%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -131,6 +131,11 @@ Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-en
 Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
 Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
 Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+Patch14:        %{_patch_src}/misc/nvidia/0006-crypto-Add-fix-for-6.13-Module-compilation.patch
+Patch15:        %{_patch_src}/misc/nvidia/0007-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch
+Patch16:        %{_patch_src}/misc/nvidia/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch
+Patch17:        %{_patch_src}/misc/nvidia/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch
+Patch18:        %{_patch_src}/misc/nvidia/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch
 %endif
 
 %description

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos1%{?_lto_args:.lto}%{?dist}
+Release:        cachyos2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -371,8 +371,6 @@ Recommends:     linux-firmware
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
-    %{_kernel_dir}/modules.builtin
-    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/symvers.zst
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
@@ -405,10 +403,9 @@ Requires:       kernel-uname-r = %{_kver}
         fi
     fi
 
-%postun modules
-    /sbin/depmod -a %{_kver}
-
 %files modules
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/modules.order
     %{_kernel_dir}/build
     %{_kernel_dir}/source

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -1,743 +1,486 @@
-### A port of linux-cachyos (https://github.com/CachyOS/linux-cachyos/tree/master/linux-cachyos) for the Fedora operating system.
-# https://github.com/CachyOS/linux-cachyos
-### The authors of linux-cachyos patchset:
-# Peter Jung ptr1337 <admin@ptr1337.dev>
-# Piotr Gorski sirlucjan <piotrgorski@cachyos.org>
-### The author of BORE-EEVDF Scheduler:
-# Masahito Suzuki <firelzrd@gmail.com>
-### The port maintainer for Fedora:
-# bieszczaders <zbyszek@linux.pl>
-# https://copr.fedorainfracloud.org/coprs/bieszczaders/
+# Maintainer: Eric Naim <dnaim@cachyos.org>
 
-%define _build_id_links none
+# Fedora bits
+%define __spec_install_post %{__os_install_post}
+%define _default_patch_fuzz 2
 %define _disable_source_fetch 0
-
-# See https://fedoraproject.org/wiki/Changes/SetBuildFlagsBuildCheck to why this has to be done
-%if 0%{?fedora} >= 37
-%undefine _auto_set_build_flags
-%endif
-
-%ifarch x86_64
-%define karch x86
-%define asmarch x86
-%endif
-
-# define git branch to make testing easier without merging to master branch
-%define _git_branch master
-
-# whether to build kernel with llvm compiler(clang)
-%define llvm_kbuild 1
-%if %{llvm_kbuild}
-%define llvm_build_env_vars CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
-%define ltoflavor 1
-%endif
-
-%define flavor cachyos
-Name: kernel%{?flavor:-%{flavor}}%{?ltoflavor:-lto}
-Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
-
-%define _basekver 6.12
-%define _stablekver 9
-%if %{_stablekver} == 0
-%define _tarkver %{_basekver}
-%else
-%define _tarkver %{_basekver}.%{_stablekver}
-%endif
-
-Version: %{_basekver}.%{_stablekver}
-
-%define customver 1
-%define flaver cb%{customver}
-
-Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
-
-# Define rawhide fedora version
-%define _rawhidever 42
-
-# Build nvidia-open alongside the kernel
-%define _nv_build 1
-%if 0%{?fedora} >= 41
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%else
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%endif
-%define _nv_open_pkg open-gpu-kernel-modules-%{_nv_ver}
-
-%define rpmver %{version}-%{release}
-%define krelstr %{release}.%{_arch}
-%define kverstr %{version}-%{krelstr}
-
-License: GPLv2 and Redistributable, no modifications permitted
-Group: System Environment/Kernel
-Vendor: The Linux Community and CachyOS maintainer(s)
-URL: https://cachyos.org
-Source0: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
-Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/config
-Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
-# Stable patches
-Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
-
-Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled.patch
-Patch4: %{_nvidia_patchurl}/0004-silence-event-assert-until-570.patch
-Patch5: %{_nvidia_patchurl}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
-Patch6: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
-
-# Dev patches
-#Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all-dev.patch
-#Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched-dev/0001-bore-cachy.patch
-%define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
-BuildRequires: python3-devel
-BuildRequires: make
-BuildRequires: perl-generators
-BuildRequires: perl-interpreter
-BuildRequires: openssl-devel
-BuildRequires: bison
-BuildRequires: flex
-BuildRequires: findutils
-BuildRequires: git-core
-BuildRequires: perl-devel
-BuildRequires: openssl
-BuildRequires: elfutils-devel
-BuildRequires: gawk
-BuildRequires: binutils
-BuildRequires: m4
-BuildRequires: tar
-BuildRequires: hostname
-BuildRequires: bzip2
-BuildRequires: bash
-BuildRequires: gzip
-BuildRequires: xz
-BuildRequires: bc
-BuildRequires: diffutils
-BuildRequires: redhat-rpm-config
-BuildRequires: net-tools
-BuildRequires: elfutils
-BuildRequires: patch
-BuildRequires: rpm-build
-BuildRequires: dwarves
-BuildRequires: kmod
-BuildRequires: libkcapi-hmaccalc
-BuildRequires: perl-Carp
-BuildRequires: rsync
-BuildRequires: grubby
-BuildRequires: wget
-BuildRequires: gcc
-BuildRequires: gcc-c++
-%if %{llvm_kbuild}
-BuildRequires: llvm
-BuildRequires: clang
-BuildRequires: lld
+%define make_build make %{?_lto_args} %{?_smp_mflags}
+%undefine __brp_mangle_shebangs
+%undefine _auto_set_build_flags
+%undefine _include_frame_pointers
+
+# Linux Kernel Versions
+%define _basekver 6.12
+%define _stablekver 10
+%define _rpmver %{version}-%{release}
+%define _kver %{_rpmver}.%{_arch}
+
+%if %{_stablekver} == 0
+    %define _tarkver %{_basekver}
+%else
+    %define _tarkver %{version}
 %endif
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore <= 6.5.10-cb1
+
+# Build a minimal a kernel via modprobed.db
+# file to reduce build times
+%define _build_minimal 0
+
+# Builds the kernel with clang and enables
+# ThinLTO
+%define _build_lto 1
+
+# Builds nvidia-open kernel modules with
+# the kernel
+%define _build_nv 1
+%define _nv_ver 565.77
+%define _nv_pkg open-gpu-kernel-modules-%{_nv_ver}
+
+# Define the tickrate used by the kernel
+# Valid values: 100, 250, 300, 500, 600, 750 and 1000
+# An invalid value will not fail and continue to use
+# 1000Hz tickrate
+%define _hz_tick 1000
+
+# Defines the x86_64 ISA level used
+# to compile the kernel
+# Valid values are 1-4
+# An invalid value will continue and use
+# x86_64_v3
+%define _x86_64_lvl 3
+
+# Define variables for directory paths
+# to be used during packaging
+%define _kernel_dir /lib/modules/%{_kver}
+%define _devel_dir %{_usrsrc}/kernels/%{_kver}
+
+%define _patch_src https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}
+
+%if %{_build_lto}
+    # Define build environment variables to build the kernel with clang
+    %define _lto_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
+%endif
+
+%define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver}
+
+Name:           kernel-cachyos%{?_lto_args:-lto}
+Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
+Version:        %{_basekver}.%{_stablekver}
+Release:        cachyos4%{?_lto_args:.lto}%{?dist}
+License:        GPL-2.0-only
+URL:            https://cachyos.org
+
+Requires:       kernel-core-uname-r = %{_kver}
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+
+BuildRequires:  bc
+BuildRequires:  bison
+BuildRequires:  dwarves
+BuildRequires:  elfutils-devel
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  gettext-devel
+BuildRequires:  kmod
+BuildRequires:  make
+BuildRequires:  openssl
+BuildRequires:  openssl-devel
+BuildRequires:  perl-Carp
+BuildRequires:  perl-devel
+BuildRequires:  perl-generators
+BuildRequires:  perl-interpreter
+BuildRequires:  python3-devel
+BuildRequires:  python3-pyyaml
+BuildRequires:  python-srpm-macros
+
+%if %{_build_lto}
+BuildRequires:  clang
+BuildRequires:  lld
+BuildRequires:  llvm
+%endif
+
+%if %{_build_nv}
+BuildRequires:  gcc-c++
+%endif
+
+# Indexes 0-9 are reserved for the kernel. 10-19 will be reserved for NVIDIA
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
+Source1:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/config
+
+%if %{_build_minimal}
+# The default modprobed.db provided is used for linux-cachyos CI.
+# This should not be used for production and ideally should only be used for compile tests.
+# Note that any modprobed.db file is accepted
+Source2:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/modprobed.db
+%endif
+
+%if %{_build_nv}
+Source10:       https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_pkg}.tar.gz
+%endif
+
+Patch0:         %{_patch_src}/all/0001-cachyos-base-all.patch
+Patch1:         %{_patch_src}/sched/0001-bore-cachy.patch
+
+%if %{_build_lto}
+Patch2:         %{_patch_src}/misc/dkms-clang.patch
+%endif
+
+%if %{_build_nv}
+Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch
+Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
+Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
+Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+%endif
 
 %description
-The kernel-%{flaver} meta package
-
-%package core
-Summary: Kernel core package
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel)
-Provides: kernel = %{rpmver}
-Provides: kernel-core = %{rpmver}
-Provides: kernel-core-uname-r = %{kverstr}
-Provides: kernel-uname-r = %{kverstr}
-Provides: kernel-%{_arch} = %{rpmver}
-Provides: kernel-core%{_isa} = %{rpmver}
-Provides: kernel-core-%{rpmver} = %{kverstr}
-Provides: %{name}-core-%{rpmver} = %{kverstr}
-Provides:  kernel-drm-nouveau = 16
-# multiver
-Provides: %{name}%{_basekver}-core = %{rpmver}
-Requires: bash
-Requires: coreutils
-Requires: dracut
-Requires: linux-firmware
-Requires: /usr/bin/kernel-install
-Requires: kernel-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-core >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-core >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-core <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-core <= 6.5.10-cb1
-%description core
-The kernel package contains the Linux kernel (vmlinuz), the core of any
-Linux operating system.  The kernel handles the basic functions
-of the operating system: memory allocation, process allocation, device
-input and output, etc.
-
-%package modules
-Summary: Kernel modules to match the core kernel
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel-module)
-Provides: %{name}%{_basekver}-modules = %{rpmver}
-Provides: kernel-modules = %{rpmver}
-Provides: kernel-modules%{_isa} = %{rpmver}
-Provides: kernel-modules-uname-r = %{kverstr}
-Provides: kernel-modules-%{_arch} = %{rpmver}
-Provides: kernel-modules-%{rpmver} = %{kverstr}
-Provides: %{name}-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-modules >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-modules >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-modules <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-modules <= 6.5.10-cb1
-%description modules
-This package provides kernel modules for the core %{?flavor:%{flavor}} kernel package.
-
-%if %{_nv_build}
-%package nvidia-open
-Summary: Prebuilt nvidia-open kernel modules to match the core kernel
-Group: System Environment/Kernel
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: nvidia-kmod >= %{_nv_ver}
-Provides: installonlypkg(kernel-module)
-Conflicts: akmod-nvidia
-Recommends: xorg-x11-drv-nvidia >= %{_nv_ver}
-%description nvidia-open
-This package provides prebuilt nvidia-open kernel modules for the core %{?flavor:%{flavor}} kernel package.
-%endif
-
-%package headers
-Summary: Header files for the Linux kernel for use by glibc
-Group: Development/System
-Provides: kernel-headers = %{kverstr}
-Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers%{_isa} = %{kverstr}
-Obsoletes: kernel-headers < %{kverstr}
-Obsoletes: glibc-kernheaders < 3.0-46
-Obsoletes: kernel-cachyos-bore-eevdf-headers <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-headers <= 6.5.10-cb1
-Provides: kernel-cachyos-bore-eevdf-headers >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-headers >= 6.5.7-cb1
-%description headers
-Kernel-headers includes the C header files that specify the interface
-between the Linux kernel and userspace libraries and programs.  The
-header files define structures and constants that are needed for
-building most standard programs and are also needed for rebuilding the
-glibc package.
-
-%package devel
-Summary: Development package for building kernel modules to match the %{?flavor:%{flavor}} kernel
-Group: System Environment/Kernel
-AutoReqProv: no
-Requires: findutils
-Requires: perl-interpreter
-Requires: openssl-devel
-Requires: flex
-Requires: make
-Requires: bison
-Requires: elfutils-libelf-devel
-Requires: gcc
-%if %{llvm_kbuild}
-Requires: clang
-Requires: llvm
-Requires: lld
-%endif
-Enhances: akmods
-Enhances: dkms
-Provides: installonlypkg(kernel)
-Provides: kernel-devel = %{rpmver}
-Provides: kernel-devel-uname-r = %{kverstr}
-Provides: kernel-devel-%{_arch} = %{rpmver}
-Provides: kernel-devel%{_isa} = %{rpmver}
-Provides: kernel-devel-%{rpmver} = %{kverstr}
-Provides: %{name}-devel-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver}-devel = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-devel >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-devel >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-devel <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-devel <= 6.5.10-cb1
-%description devel
-This package provides kernel headers and makefiles sufficient to build modules
-against the %{?flavor:%{flavor}} kernel package.
-
-%package devel-matched
-Summary: Meta package to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel
-Requires: %{name}-devel = %{rpmver},
-Requires: %{name}-core = %{rpmver}
-Provides: kernel-devel-matched = %{rpmver}
-Provides: kernel-devel-matched%{_isa} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-devel-matched >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-devel-matched >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-devel-matched <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-devel-matched <= 6.5.10-cb1
-%description devel-matched
-This meta package is used to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel.
+    The meta package for %{name}.
 
 %prep
-%setup -q -n linux-%{_tarkver}
+    %setup -q %{?SOURCE10:-b 10} -n linux-%{_tarkver}
+    %autopatch -p1 -v -M 9
 
-tar -xzf %{SOURCE2} -C %{_builddir}
+    cp %{SOURCE1} .config
 
-# Apply CachyOS patch
-patch -p1 -i %{PATCH0}
+    # Default configs to always enable
+    # Enable CACHY sauce and the scheduler
+    # used in the default linux-cachyos kernel
+    scripts/config -e CACHY -e SCHED_BORE
 
-# Apply EEVDF and BORE patches
-patch -p1 -i %{PATCH1}
+    # Use SElinux by default
+    # https://github.com/sirlucjan/copr-linux-cachyos/pull/1
+    scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
-### Apply patches for nvidia-open
-# Set modeset and fbdev to default enabled
-patch -p1 -i %{PATCH3} -d %{_builddir}/%{_nv_open_pkg}/kernel-open
-# Silence Assert warnings
-patch -p1 -i %{PATCH4} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix for Zen5 error print in dmesg
-patch -p1 -i %{PATCH5} -d %{_builddir}/%{_nv_open_pkg}/
-# Patches for Nvidia on kernel 6.12
-patch -p1 -i %{PATCH6} -d %{_builddir}/%{_nv_open_pkg}/
+    # Do not change the system's hostname
+    scripts/config -u DEFAULT_HOSTNAME
 
-# Fetch the config and move it to the proper directory
-cp %{SOURCE1} .config
+    case %{_hz_tick} in
+        100|250|300|500|600|750|1000)
+            scripts/config -e HZ_%{_hz_tick} --set-val HZ %{_hz_tick};;
+        *)
+            echo "Invalid tickrate value, using default 1000"
+            scripts/config -e HZ_1000 --set-val HZ 1000;;
+    esac
 
-# Remove CachyOS's localversion
-find . -name "localversion*" -delete
-scripts/config -u LOCALVERSION
+    %if %{_x86_64_lvl} < 5 && %{_x86_64_lvl} > 0
+        scripts/config --set-val X86_64_VERSION %{_x86_64_lvl}
+    %else
+        echo "Invalid x86_64 ISA Level. Using x86_64_v3"
+        scripts/config --set-val X86_64_VERSION 3
+    %endif
 
-# Enable CachyOS tweaks
-scripts/config -e CACHY
+    %if %{_build_lto}
+        scripts/config -e LTO_CLANG_THIN
+    %endif
 
-# Enable BORE Scheduler
-scripts/config -e SCHED_BORE
+    %if %{_build_minimal}
+        %make_build LSMOD=%{SOURCE2} localmodconfig
+    %else
+        %make_build olddefconfig
+    %endif
 
-# Enable sched-ext
-scripts/config -e SCHED_CLASS_EXT
-scripts/config -e BPF
-scripts/config -e BPF_EVENTS
-scripts/config -e BPF_JIT
-scripts/config -e BPF_SYSCALL
-scripts/config -e DEBUG_INFO
-scripts/config -e DEBUG_INFO_BTF
-scripts/config -e DEBUG_INFO_BTF_MODULES
-scripts/config -e FTRACE
-scripts/config -e PAHOLE_HAS_SPLIT_BTF
-scripts/config -e DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT
-scripts/config -e SCHED_DEBUG
+    diff -u %{SOURCE1} .config || :
 
-# Setting tick rate
-scripts/config -d HZ_300
-scripts/config -e HZ_1000
-scripts/config --set-val HZ 1000
-
-# Enable x86_64_v3
-# Just to be sure, check:
-# /lib/ld-linux-x86-64.so.2 --help | grep supported
-# and make sure if your processor supports it:
-# x86-64-v3 (supported, searched)
-scripts/config --set-val X86_64_VERSION 3
-
-# Set O3
-scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE
-scripts/config -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
-
-# Enable full ticks
-scripts/config -d HZ_PERIODIC
-scripts/config -d NO_HZ_IDLE
-scripts/config -d CONTEXT_TRACKING_FORCE
-scripts/config -e NO_HZ_FULL_NODEF
-scripts/config -e NO_HZ_FULL
-scripts/config -e NO_HZ
-scripts/config -e NO_HZ_COMMON
-scripts/config -e CONTEXT_TRACKING
-
-# Enable full preempt
-scripts/config -e PREEMPT_BUILD
-scripts/config -d PREEMPT_NONE
-scripts/config -d PREEMPT_VOLUNTARY
-scripts/config -e PREEMPT
-scripts/config -e PREEMPT_COUNT
-scripts/config -e PREEMPTION
-scripts/config -e PREEMPT_DYNAMIC
-
-# Enable thin lto
-%if %{llvm_kbuild}
-scripts/config -e LTO
-scripts/config -e LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG_THIN
-scripts/config -d LTO_NONE
-scripts/config -e HAS_LTO_CLANG
-scripts/config -d LTO_CLANG_FULL
-scripts/config -e LTO_CLANG_THIN
-scripts/config -e HAVE_GCC_PLUGINS
-%endif
-
-# Unset hostname
-scripts/config -u DEFAULT_HOSTNAME
-
-# Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
-
-# Set kernel version string as build salt
-scripts/config --set-str BUILD_SALT "%{kverstr}"
-
-# Finalize the patched config
-#make %{?_smp_mflags} EXTRAVERSION=-%{krelstr} oldconfig
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr} olddefconfig
-
-# Save configuration for later reuse
-cat .config > config-linux-bore
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}/kernel-open
+        %patch -P 10 -p1
+        cd ..
+        %autopatch -p1 -v -m 11 -M 19
+    %endif
 
 %build
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr}
-%if %{llvm_kbuild}
-clang ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%else
-gcc ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%endif
+    %make_build EXTRAVERSION=-%{release}.%{_arch} all
+    %make_build -C tools/bpf/bpftool vmlinux.h feature-clang-bpf-co-re=1
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-CFLAGS= CXXFLAGS= LDFLAGS= make %{?llvm_build_env_vars} KERNEL_UNAME=%{kverstr} IGNORE_PREEMPT_RT_PRESENCE=1 IGNORE_CC_MISMATCH=yes SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver} %{?_smp_mflags} modules
-%endif
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        CFLAGS= CXXFLAGS= LDFLAGS= %make_build %{_module_args} IGNORE_CC_MISMATCH=yes modules
+    %endif
 
 %install
+    echo "Installing the kernel image..."
+    install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
+    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
 
-ImageName=$(make image_name | tail -n 1)
+    echo "Installing kernel modules..."
+    ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
 
-mkdir -p %{buildroot}/boot
+    echo "Installing files for the development package..."
+    install -Dt %{buildroot}%{_devel_dir} -m644 .config Makefile Module.symvers System.map tools/bpf/bpftool/vmlinux.h
+    cp .config %{buildroot}%{_kernel_dir}/config
+    cp System.map %{buildroot}%{_kernel_dir}/System.map
+    cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts
+    rm -rf %{buildroot}%{_devel_dir}/include
+    cp -a scripts %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts/tracing
+    rm -f %{buildroot}%{_devel_dir}/scripts/spdxcheck.py
 
-cp -v $ImageName %{buildroot}/boot/vmlinuz-%{kverstr}
-chmod 755 %{buildroot}/boot/vmlinuz-%{kverstr}
+    # The cp commands below are needed for parity with Fedora's packaging
+    # Install files that are needed for `make scripts` to succeed
+    cp -a --parents security/selinux/include/classmap.h %{buildroot}%{_devel_dir}
+    cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}%{_devel_dir}
 
-ZSTD_CLEVEL=19 make %{?_smp_mflags} %{?llvm_build_env_vars} INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_STRIP=1 modules_install mod-fw=
-make %{?_smp_mflags} %{?llvm_build_env_vars} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
+    # Install files that are needed for `make prepare` to succeed -- Generic
+    cp -a --parents tools/include/linux/compiler* %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux/types.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/build/Build.include %{buildroot}%{_devel_dir}
+    cp --parents tools/build/fixdep.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/sync-check.sh %{buildroot}%{_devel_dir}
+    cp -a --parents tools/bpf/resolve_btfids %{buildroot}%{_devel_dir}
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-install -dm755 "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -Dt "%{buildroot}/usr/share/licenses/nvidia-open" -m644 COPYING
-find "%{buildroot}" -name '*.ko' -exec zstd --rm -19 {} +
-%endif
+    cp --parents security/selinux/include/policycap_names.h %{buildroot}%{_devel_dir}
+    cp --parents security/selinux/include/policycap.h %{buildroot}%{_devel_dir}
 
-# prepare -devel files
-### all of the things here are derived from the Fedora kernel.spec
-### see
-##### https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec
-cd %{_builddir}/linux-%{_tarkver}
-rm -f %{buildroot}/lib/modules/%{kverstr}/build
-rm -f %{buildroot}/lib/modules/%{kverstr}/source
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build
-(cd %{buildroot}/lib/modules/%{kverstr} ; ln -s build source)
-# dirs for additional modules per module-init-tools, kbuild/modules.txt
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/updates
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/weak-updates
-# CONFIG_KERNEL_HEADER_TEST generates some extra files in the process of
-# testing so just delete
-find . -name *.h.s -delete
-# first copy everything
-cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}/lib/modules/%{kverstr}/build
-if [ ! -e Module.symvers ]; then
-touch Module.symvers
-fi
-cp Module.symvers %{buildroot}/lib/modules/%{kverstr}/build
-cp System.map %{buildroot}/lib/modules/%{kverstr}/build
-if [ -s Module.markers ]; then
-cp Module.markers %{buildroot}/lib/modules/%{kverstr}/build
-fi
+    cp -a --parents tools/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/vdso %{buildroot}%{_devel_dir}
+    cp --parents tools/scripts/utilities.mak %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/subcmd %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/*.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/*.[ch] %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/Build %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/include/objtool/*.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/bpf %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/bpf/Build %{buildroot}%{_devel_dir}
 
-# create the kABI metadata for use in packaging
-# NOTENOTE: the name symvers is used by the rpm backend
-# NOTENOTE: to discover and run the /usr/lib/rpm/fileattrs/kabi.attr
-# NOTENOTE: script which dynamically adds exported kernel symbol
-# NOTENOTE: checksums to the rpm metadata provides list.
-# NOTENOTE: if you change the symvers name, update the backend too
-echo "**** GENERATING kernel ABI metadata ****"
-gzip -c9 < Module.symvers > %{buildroot}/boot/symvers-%{kverstr}.gz
-cp %{buildroot}/boot/symvers-%{kverstr}.gz %{buildroot}/lib/modules/%{kverstr}/symvers.gz
+    # Misc headers
+    cp -a --parents arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a include %{buildroot}%{_devel_dir}/include
+    cp -a sound/soc/sof/sof-audio.h %{buildroot}%{_devel_dir}/sound/soc/sof
+    cp -a tools/objtool/objtool %{buildroot}%{_devel_dir}/tools/objtool/
+    cp -a tools/objtool/fixdep %{buildroot}%{_devel_dir}/tools/objtool/
 
-# then drop all but the needed Makefiles/Kconfig files
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/include
-cp .config %{buildroot}/lib/modules/%{kverstr}/build
-cp -a scripts %{buildroot}/lib/modules/%{kverstr}/build
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts/tracing
-rm -f %{buildroot}/lib/modules/%{kverstr}/build/scripts/spdxcheck.py
+    # Install files that are needed for `make prepare` to succeed -- for x86_64
+    cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/stack.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/ctype.h %{buildroot}%{_devel_dir}
 
-%ifarch s390x
-# CONFIG_EXPOLINE_EXTERN=y produces arch/s390/lib/expoline/expoline.o
-# which is needed during external module build.
-if [ -f arch/s390/lib/expoline/expoline.o ]; then
-cp -a --parents arch/s390/lib/expoline/expoline.o %{buildroot}/lib/modules/%{kverstr}/build
-fi
-%endif
+    cp -a --parents scripts/syscalltbl.sh %{buildroot}%{_devel_dir}
+    cp -a --parents scripts/syscallhdr.sh %{buildroot}%{_devel_dir}
 
-# Files for 'make scripts' to succeed with kernel-devel.
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/security/selinux/include
-cp -a --parents security/selinux/include/classmap.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}/lib/modules/%{kverstr}/build
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/tools/include/tools
-cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
+    cp -a --parents tools/arch/x86/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/lib %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/lib/ %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/ %{buildroot}%{_devel_dir}
 
-# Files for 'make prepare' to succeed with kernel-devel.
-cp -a --parents tools/include/linux/compiler* %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux/types.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/build/Build.include %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/fixdep.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/sync-check.sh %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/bpf/resolve_btfids %{buildroot}/lib/modules/%{kverstr}/build
+    # Final cleanups ala Fedora
+    echo "Cleaning up development files..."
+    find %{buildroot}%{_devel_dir}/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    find %{buildroot}%{_devel_dir}/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    touch -r %{buildroot}%{_devel_dir}/Makefile \
+        %{buildroot}%{_devel_dir}/include/generated/uapi/linux/version.h \
+        %{buildroot}%{_devel_dir}/include/config/auto.conf
 
-cp --parents security/selinux/include/policycap_names.h %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents security/selinux/include/policycap.h %{buildroot}/lib/modules/%{kverstr}/build
+    # These links will be owned by the modules package, creating a broken
+    # link unless the -devel package is installed. why??
+    rm -rf %{buildroot}%{_kernel_dir}/build
+    ln -s %{_devel_dir} %{buildroot}%{_kernel_dir}/build
+    ln -s %{_kernel_dir}/build %{buildroot}%{_kernel_dir}/source
 
-cp -a --parents tools/include/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/vdso %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/scripts/utilities.mak %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/subcmd %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/*.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/*.[ch] %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/include/objtool/*.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/bpf %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/bpf/Build %{buildroot}/lib/modules/%{kverstr}/build
+    # Create stub initramfs to inflate disk space requirements.
+    # This should hopefully prevent some initramfs failures due to
+    # insufficient space in /boot (#bz #530778)
+    # 90 seems to be a safe value nowadays. It is slightly inflated than the
+    # measured average to also account for installed vmlinuz in /boot
+    echo "Creating stub initramfs..."
+    install -dm755 %{buildroot}/boot
+    dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{_kver}.img bs=1M count=90
 
-if [ -f tools/objtool/objtool ]; then
-  cp -a tools/objtool/objtool %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -f tools/objtool/fixdep ]; then
-  cp -a tools/objtool/fixdep %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -d arch/%{karch}/scripts ]; then
-  cp -a arch/%{karch}/scripts %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch} || :
-fi
-if [ -f arch/%{karch}/*lds ]; then
-  cp -a arch/%{karch}/*lds %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch}/ || :
-fi
-if [ -f arch/%{asmarch}/kernel/module.lds ]; then
-  cp -a --parents arch/%{asmarch}/kernel/module.lds %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-find %{buildroot}/lib/modules/%{kverstr}/build/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-%ifarch ppc64le
-cp -a --parents arch/powerpc/lib/crtsavres.[So] %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-if [ -d arch/%{asmarch}/include ]; then
-  cp -a --parents arch/%{asmarch}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-%ifarch aarch64
-# arch/arm64/include/asm/xen references arch/arm
-cp -a --parents arch/arm/include/asm/xen %{buildroot}/lib/modules/%{kverstr}/build/
-# arch/arm64/include/asm/opcodes.h references arch/arm
-cp -a --parents arch/arm/include/asm/opcodes.h %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-# include the machine specific headers for ARM variants, if available.
-%ifarch %{arm}
-if [ -d arch/%{asmarch}/mach-${Variant}/include ]; then
-  cp -a --parents arch/%{asmarch}/mach-${Variant}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-# include a few files for 'make prepare'
-cp -a --parents arch/arm/tools/gen-mach-types %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/arm/tools/mach-types %{buildroot}/lib/modules/%{kverstr}/build/
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        echo "Installing NVIDIA open kernel modules..."
+        install -Dt %{buildroot}%{_kernel_dir}/nvidia -m644 kernel-open/*.ko
+        find %{buildroot}%{_kernel_dir}/nvidia -name '*.ko' -exec zstd --rm -19 {} +
+        install -Dt %{buildroot}/%{_defaultlicensedir}/%{name}-nvidia-open -m644 COPYING
+    %endif
 
-%endif
-cp -a include %{buildroot}/lib/modules/%{kverstr}/build/include
+%package core
+Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
+AutoReq:        no
+Conflicts:      xfsprogs < 4.3.0-1
+Conflicts:      xorg-x11-drv-vmmouse < 13.0.99
+Provides:       kernel = %{_rpmver}
+Provides:       kernel-core-uname-r = %{_kver}
+Provides:       kernel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires(pre):  /usr/bin/kernel-install
+Requires(pre):  coreutils
+Requires(pre):  dracut >= 027
+Requires(pre):  systemd >= 203-2
+Requires(pre):  ((linux-firmware >= 20150904-56.git6ebf5d57) if linux-firmware)
+Requires(preun):systemd >= 200
+Recommends:     linux-firmware
 
-%ifarch i686 x86_64
-# files for 'make prepare' to succeed with kernel-devel
-cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/stack.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/ctype.h %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents scripts/syscalltbl.sh %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents scripts/syscallhdr.sh %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents tools/arch/x86/include/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/lib %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/lib/ %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/ %{buildroot}/lib/modules/%{kverstr}/build
-
-%endif
-# Clean up intermediate tools files
-find %{buildroot}/lib/modules/%{kverstr}/build/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-
-# Make sure the Makefile, version.h, and auto.conf have a matching
-# timestamp so that external modules can be built
-touch -r %{buildroot}/lib/modules/%{kverstr}/build/Makefile \
-%{buildroot}/lib/modules/%{kverstr}/build/include/generated/uapi/linux/version.h \
-%{buildroot}/lib/modules/%{kverstr}/build/include/config/auto.conf
-
-find %{buildroot}/lib/modules/%{kverstr} -name "*.ko" -type f >modnames
-
-# mark modules executable so that strip-to-file can strip them
-xargs --no-run-if-empty chmod u+x < modnames
-
-# Generate a list of modules for block and networking.
-
-grep -F /drivers/ modnames | xargs --no-run-if-empty nm -upA |
-sed -n 's,^.*/\([^/]*\.ko\):  *U \(.*\)$,\1 \2,p' > drivers.undef
-
-collect_modules_list()
-{
-  sed -r -n -e "s/^([^ ]+) \\.?($2)\$/\\1/p" drivers.undef |
-LC_ALL=C sort -u > %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  if [ ! -z "$3" ]; then
-sed -r -e "/^($3)\$/d" -i %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  fi
-}
-
-collect_modules_list networking \
-  'register_netdev|ieee80211_register_hw|usbnet_probe|phy_driver_register|rt(l_|2x00)(pci|usb)_probe|register_netdevice'
-collect_modules_list block \
-  'ata_scsi_ioctl|scsi_add_host|scsi_add_host_with_dma|blk_alloc_queue|blk_init_queue|register_mtd_blktrans|scsi_esp_register|scsi_register_device_handler|blk_queue_physical_block_size' 'pktcdvd.ko|dm-mod.ko'
-collect_modules_list drm \
-  'drm_open|drm_init'
-collect_modules_list modesetting \
-  'drm_crtc_init'
-
-# detect missing or incorrect license tags
-( find %{buildroot}/lib/modules/%{kverstr} -name '*.ko' | xargs /sbin/modinfo -l | \
-grep -E -v 'GPL( v2)?$|Dual BSD/GPL$|Dual MPL/GPL$|GPL and additional rights$' ) && exit 1
-
-remove_depmod_files()
-{
-# remove files that will be auto generated by depmod at rpm -i time
-pushd %{buildroot}/lib/modules/%{kverstr}/
-rm -f modules.{alias,alias.bin,builtin.alias.bin,builtin.bin} \
-  modules.{dep,dep.bin,devname,softdep,symbols,symbols.bin}
-popd
-}
-
-remove_depmod_files
-
-mkdir -p %{buildroot}%{_prefix}/src/kernels
-mv %{buildroot}/lib/modules/%{kverstr}/build %{buildroot}%{_prefix}/src/kernels/%{kverstr}
-
-# This is going to create a broken link during the build, but we don't use
-# it after this point.  We need the link to actually point to something
-# when kernel-devel is installed, and a relative link doesn't work across
-# the F17 UsrMove feature.
-ln -sf %{_prefix}/src/kernels/%{kverstr} %{buildroot}/lib/modules/%{kverstr}/build
-
-find %{buildroot}%{_prefix}/src/kernels -name ".*.cmd" -delete
-#
-
-cp -v System.map %{buildroot}/boot/System.map-%{kverstr}
-cp -v System.map %{buildroot}/lib/modules/%{kverstr}/System.map
-cp -v .config %{buildroot}/boot/config-%{kverstr}
-cp -v .config %{buildroot}/lib/modules/%{kverstr}/config
-
-(cd "%{buildroot}/boot/" && sha512hmac "vmlinuz-%{kverstr}" > ".vmlinuz-%{kverstr}.hmac")
-
-cp -v  %{buildroot}/boot/vmlinuz-%{kverstr} %{buildroot}/lib/modules/%{kverstr}/vmlinuz
-(cd "%{buildroot}/lib/modules/%{kverstr}" && sha512hmac vmlinuz > .vmlinuz.hmac)
-
-# create dummy initramfs image to inflate the disk space requirement for the initramfs. 48M seems to be the right size nowadays with more and more hardware requiring initramfs-located firmware to work properly (for reference, Fedora has it set to 20M)
-dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{kverstr}.img bs=1M count=48
-
-%clean
-rm -rf %{buildroot}
+%description core
+    The kernel package contains the Linux kernel (vmlinuz), the core of any
+    Linux operating system.  The kernel handles the basic functions
+    of the operating system: memory allocation, process allocation, device
+    input and output, etc.
 
 %post core
-if [ `uname -i` == "x86_64" -o `uname -i` == "i386" ] &&
-   [ -f /etc/sysconfig/kernel ]; then
-  /bin/sed -r -i -e 's/^DEFAULTKERNEL=kernel-smp$/DEFAULTKERNEL=kernel/' /etc/sysconfig/kernel || exit $?
-fi
-if [ -x /bin/kernel-install ] && [ -d /boot ]; then
-/bin/kernel-install add %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-fi
+    mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+    touch %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
 
 %posttrans core
-if [ ! -z $(rpm -qa | grep grubby) ]; then
-  grubby --set-default="/boot/vmlinuz-%{kverstr}"
-fi
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
+        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
+            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+            if command -v restorecon &>/dev/null; then
+                restorecon "/boot/symvers-%{_kver}.zst"
+            fi
+        fi
+    fi
 
 %preun core
-/bin/kernel-install remove %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-if [ -x /usr/sbin/weak-modules ]
-then
-/usr/sbin/weak-modules --remove-kernel %{kverstr} || exit $?
-fi
-
-%post devel
-if [ -f /etc/sysconfig/kernel ]
-then
-. /etc/sysconfig/kernel || exit $?
-fi
-if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]
-then
-(cd /usr/src/kernels/%{kverstr} &&
- /usr/bin/find . -type f | while read f; do
-   hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f 2>&1 >/dev/null
- done)
-fi
-
-%post modules
-/sbin/depmod -a %{kverstr}
-
-%if %{_nv_build}
-%posttrans nvidia-open
-/sbin/depmod -a %{kverstr}
-%endif
+    /bin/kernel-install remove %{_kver} || exit $?
+    if [ -x /usr/sbin/weak-modules ]; then
+        /usr/sbin/weak-modules --remove-kernel %{_kver} || exit $?
+    fi
 
 %files core
-%ghost %attr(0600, root, root) /boot/vmlinuz-%{kverstr}
-%ghost %attr(0600, root, root) /boot/System.map-%{kverstr}
-%ghost %attr(0600, root, root) /boot/initramfs-%{kverstr}.img
-%ghost %attr(0600, root, root) /boot/symvers-%{kverstr}.gz
-%ghost %attr(0644, root, root) /boot/config-%{kverstr}
-/boot/.vmlinuz-%{kverstr}.hmac
-%dir /lib/modules/%{kverstr}/
-/lib/modules/%{kverstr}/.vmlinuz.hmac
-/lib/modules/%{kverstr}/config
-/lib/modules/%{kverstr}/vmlinuz
-/lib/modules/%{kverstr}/System.map
-/lib/modules/%{kverstr}/symvers.gz
+    %dir %{_kernel_dir}
+    %license COPYING
+    %ghost /boot/initramfs-%{_kver}.img
+    %{_kernel_dir}/vmlinuz
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
+    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/config
+    %{_kernel_dir}/System.map
+
+%package modules
+Summary:        Kernel modules package for %{name}
+Provides:       kernel-modules = %{_rpmver}
+Provides:       kernel-modules-core = %{_rpmver}
+Provides:       kernel-modules-uname-r = %{_kver}
+Provides:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+
+%description modules
+    This package provides kernel modules for the %{name}-core kernel package.
+
+%post modules
+    /sbin/depmod -a %{_kver}
+    if [ ! -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver} ]; then
+        mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+        touch %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    fi
+
+%posttrans modules
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        if [ -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver} ]; then
+            echo "Running: dracut -f --kver %{_kver}"
+            dracut -f --kver "%{_kver}" || exit $?
+        fi
+    fi
+
+%postun modules
+    /sbin/depmod -a %{_kver}
 
 %files modules
-/lib/modules/%{kverstr}/
-%exclude /lib/modules/%{kverstr}/.vmlinuz.hmac
-%exclude /lib/modules/%{kverstr}/config
-%exclude /lib/modules/%{kverstr}/vmlinuz
-%exclude /lib/modules/%{kverstr}/System.map
-%exclude /lib/modules/%{kverstr}/symvers.gz
-%exclude /lib/modules/%{kverstr}/build
-%exclude /lib/modules/%{kverstr}/source
-%if %{_nv_build}
-%exclude /lib/modules/%{kverstr}/nvidia
+    %{_kernel_dir}/modules.order
+    %{_kernel_dir}/build
+    %{_kernel_dir}/source
+    %{_kernel_dir}/kernel
 
-%files nvidia-open
-/lib/modules/%{kverstr}/nvidia
-/usr/share/licenses/nvidia-open/COPYING
+%package devel
+Summary:        Development package for building kernel modules to match %{name}
+Provides:       kernel-devel = %{_rpmver}
+Provides:       kernel-devel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+AutoReqProv:    no
+Requires(pre):  findutils
+Requires:       findutils
+Requires:       perl-interpreter
+Requires:       openssl-devel
+Requires:       elfutils-libelf-devel
+Requires:       bison
+Requires:       flex
+Requires:       make
+
+%if %{_build_lto}
+Requires:       clang
+Requires:       lld
+Requires:       llvm
+%else
+Requires:       gcc
 %endif
 
-%files headers
-%defattr (-, root, root)
-/usr/include/*
+%description devel
+    This package provides kernel headers and makefiles sufficient to build modules against %{name}.
+
+%post devel
+    if [ -f /etc/sysconfig/kernel ]; then
+        . /etc/sysconfig/kernel || exit $?
+    fi
+    if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]; then
+        (cd /usr/src/kernels/%{_kver} &&
+        /usr/bin/find . -type f | while read f; do
+            hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f > /dev/null
+        done;
+        )
+    fi
 
 %files devel
-%defattr (-, root, root)
-/usr/src/kernels/%{kverstr}
-/lib/modules/%{kverstr}/build
-/lib/modules/%{kverstr}/source
+    %{_devel_dir}
+
+%package devel-matched
+Summary:        Meta package to install matching core and devel packages for %{name}
+Provides:       kernel-devel-matched = %{_rpmver}
+Requires:       %{name}-core = %{_rpmver}
+Requires:       %{name}-devel = %{_rpmver}
+
+%description devel-matched
+    This meta package is used to install matching core and devel packages for %{name}.
 
 %files devel-matched
 
+%if %{_build_nv}
+%package nvidia-open
+Summary:        nvidia-open %{_nv_ver} kernel modules for %{name}
+Provides:       nvidia-kmod >= %{_nv_ver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+Conflicts:      akmod-nvidia
+Recommends:     xorg-x11-drv-nvidia >= %{_nv_ver}
+
+%description nvidia-open
+    This package provides nvidia-open %{_nv_ver} kernel modules for %{name}.
+
+%post nvidia-open
+    /sbin/depmod -a %{_kver}
+
+%files nvidia-open
+    %license %{_defaultlicensedir}/%{name}-nvidia-open/COPYING
+    %{_kernel_dir}/nvidia
+%endif
+
 %files
+
+

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos-lts%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachylts1%{?_lto_args:.lto}%{?dist}
+Release:        cachylts2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -366,8 +366,6 @@ Recommends:     linux-firmware
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
-    %{_kernel_dir}/modules.builtin
-    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/symvers.zst
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
@@ -400,10 +398,9 @@ Requires:       kernel-uname-r = %{_kver}
         fi
     fi
 
-%postun modules
-    /sbin/depmod -a %{_kver}
-
 %files modules
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/modules.order
     %{_kernel_dir}/build
     %{_kernel_dir}/source

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -1,728 +1,486 @@
-### A port of linux-cachyos-lts (https://github.com/CachyOS/linux-cachyos/tree/master/linux-cachyos-lts) for the Fedora operating system.
-# https://github.com/CachyOS/linux-cachyos
-### The authors of linux-cachyos patchset:
-# Peter Jung ptr1337 <admin@ptr1337.dev>
-# Piotr Gorski sirlucjan <piotrgorski@cachyos.org>
-### The author of BORE-EEVDF Scheduler:
-# Masahito Suzuki <firelzrd@gmail.com>
-### The port maintainer for Fedora:
-# bieszczaders <zbyszek@linux.pl>
-# https://copr.fedorainfracloud.org/coprs/bieszczaders/
+# Maintainer: Eric Naim <dnaim@cachyos.org>
 
-%define _build_id_links none
+# Fedora bits
+%define __spec_install_post %{__os_install_post}
+%define _default_patch_fuzz 2
 %define _disable_source_fetch 0
-
-# See https://fedoraproject.org/wiki/Changes/SetBuildFlagsBuildCheck to why this has to be done
-%if 0%{?fedora} >= 37
-%undefine _auto_set_build_flags
-%endif
-
-%ifarch x86_64
-%define karch x86
-%define asmarch x86
-%endif
-
-# define git branch to make testing easier without merging to master branch
-%define _git_branch master
-
-# whether to build kernel with llvm compiler(clang)
-%define llvm_kbuild 1
-%if %{llvm_kbuild}
-%define llvm_build_env_vars CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
-%define ltoflavor 1
-%endif
-
-%define flavor cachyos-lts
-Name: kernel%{?flavor:-%{flavor}}%{?ltoflavor:-lto}
-Summary: The Linux Kernel with Cachyos-LTS Patches
-
-%define _basekver 6.6
-%define _stablekver 71
-%if %{_stablekver} == 0
-%define _tarkver %{_basekver}
-%else
-%define _tarkver %{_basekver}.%{_stablekver}
-%endif
-
-Version: %{_basekver}.%{_stablekver}
-
-%define customver 1
-%define flaver clts%{customver}
-
-Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
-
-# Define rawhide fedora version
-%define _rawhidever 42
-
-# Build nvidia-open alongside the kernel
-%define _nv_build 1
-%if 0%{?fedora} >= 41
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%else
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%endif
-%define _nv_open_pkg open-gpu-kernel-modules-%{_nv_ver}
-
-%define rpmver %{version}-%{release}
-%define krelstr %{release}.%{_arch}
-%define kverstr %{version}-%{krelstr}
-
-License: GPLv2 and Redistributable, no modifications permitted
-Group: System Environment/Kernel
-Vendor: The Linux Community and CachyOS maintainer(s)
-URL: https://cachyos.org
-Source0: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
-Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-lts/config
-Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
-# Stable patches
-Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
-Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/0001-openssl-provider.patch
-
-Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled.patch
-Patch4: %{_nvidia_patchurl}/0006-silence-event-assert-until-570.patch
-Patch5: %{_nvidia_patchurl}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
-Patch6: %{_nvidia_patchurl}/0009-fix-hdmi-names.patch
-# Dev patches
-#Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all-dev.patch
-#Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched-dev/0001-bore-cachy.patch
-%define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
-BuildRequires: python3-devel
-BuildRequires: make
-BuildRequires: perl-generators
-BuildRequires: perl-interpreter
-BuildRequires: openssl-devel
-BuildRequires: bison
-BuildRequires: flex
-BuildRequires: findutils
-BuildRequires: git-core
-BuildRequires: perl-devel
-BuildRequires: openssl
-BuildRequires: elfutils-devel
-BuildRequires: gawk
-BuildRequires: binutils
-BuildRequires: m4
-BuildRequires: tar
-BuildRequires: hostname
-BuildRequires: bzip2
-BuildRequires: bash
-BuildRequires: gzip
-BuildRequires: xz
-BuildRequires: bc
-BuildRequires: diffutils
-BuildRequires: redhat-rpm-config
-BuildRequires: net-tools
-BuildRequires: elfutils
-BuildRequires: patch
-BuildRequires: rpm-build
-BuildRequires: dwarves
-BuildRequires: kmod
-BuildRequires: libkcapi-hmaccalc
-BuildRequires: perl-Carp
-BuildRequires: rsync
-BuildRequires: grubby
-BuildRequires: wget
-BuildRequires: gcc
-BuildRequires: gcc-c++
-%if %{llvm_kbuild}
-BuildRequires: llvm
-BuildRequires: clang
-BuildRequires: lld
-%endif
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
+%define make_build make %{?_lto_args} %{?_smp_mflags}
+%undefine __brp_mangle_shebangs
+%undefine _auto_set_build_flags
+%undefine _include_frame_pointers
 
+# Linux Kernel Versions
+%define _basekver 6.12
+%define _stablekver 10
+%define _rpmver %{version}-%{release}
+%define _kver %{_rpmver}.%{_arch}
+
+%if %{_stablekver} == 0
+    %define _tarkver %{_basekver}
+%else
+    %define _tarkver %{version}
+%endif
+
+# Build a minimal a kernel via modprobed.db
+# file to reduce build times
+%define _build_minimal 0
+
+# Builds the kernel with clang and enables
+# ThinLTO
+%define _build_lto 1
+
+# Builds nvidia-open kernel modules with
+# the kernel
+%define _build_nv 1
+%define _nv_ver 565.77
+%define _nv_pkg open-gpu-kernel-modules-%{_nv_ver}
+
+# Define the tickrate used by the kernel
+# Valid values: 100, 250, 300, 500, 600, 750 and 1000
+# An invalid value will not fail and continue to use
+# 1000Hz tickrate
+%define _hz_tick 1000
+
+# Defines the x86_64 ISA level used
+# to compile the kernel
+# Valid values are 1-4
+# An invalid value will continue and use
+# x86_64_v3
+%define _x86_64_lvl 3
+
+# Define variables for directory paths
+# to be used during packaging
+%define _kernel_dir /lib/modules/%{_kver}
+%define _devel_dir %{_usrsrc}/kernels/%{_kver}
+
+%define _patch_src https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}
+
+%if %{_build_lto}
+    # Define build environment variables to build the kernel with clang
+    %define _lto_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
+%endif
+
+%define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver}
+
+Name:           kernel-cachyos-lts%{?_lto_args:-lto}
+Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
+Version:        %{_basekver}.%{_stablekver}
+Release:        cachylts1%{?_lto_args:.lto}%{?dist}
+License:        GPL-2.0-only
+URL:            https://cachyos.org
+
+Requires:       kernel-core-uname-r = %{_kver}
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+
+BuildRequires:  bc
+BuildRequires:  bison
+BuildRequires:  dwarves
+BuildRequires:  elfutils-devel
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  gettext-devel
+BuildRequires:  kmod
+BuildRequires:  make
+BuildRequires:  openssl
+BuildRequires:  openssl-devel
+BuildRequires:  perl-Carp
+BuildRequires:  perl-devel
+BuildRequires:  perl-generators
+BuildRequires:  perl-interpreter
+BuildRequires:  python3-devel
+BuildRequires:  python3-pyyaml
+BuildRequires:  python-srpm-macros
+
+%if %{_build_lto}
+BuildRequires:  clang
+BuildRequires:  lld
+BuildRequires:  llvm
+%endif
+
+%if %{_build_nv}
+BuildRequires:  gcc-c++
+%endif
+
+# Indexes 0-9 are reserved for the kernel. 10-19 will be reserved for NVIDIA
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
+Source1:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-lts/config
+
+%if %{_build_minimal}
+# The default modprobed.db provided is used for linux-cachyos CI.
+# This should not be used for production and ideally should only be used for compile tests.
+# Note that any modprobed.db file is accepted
+Source2:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/modprobed.db
+%endif
+
+%if %{_build_nv}
+Source10:       https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_pkg}.tar.gz
+%endif
+
+Patch0:         %{_patch_src}/all/0001-cachyos-base-all.patch
+Patch1:         %{_patch_src}/sched/0001-bore-cachy.patch
+
+%if %{_build_lto}
+Patch2:         %{_patch_src}/misc/dkms-clang.patch
+%endif
+
+%if %{_build_nv}
+Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch
+Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
+Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
+Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+%endif
 
 %description
-The kernel-%{flaver} meta package
-
-%package core
-Summary: Kernel core package
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel)
-Provides: kernel = %{rpmver}
-Provides: kernel-core = %{rpmver}
-Provides: kernel-core-uname-r = %{kverstr}
-Provides: kernel-uname-r = %{kverstr}
-Provides: kernel-%{_arch} = %{rpmver}
-Provides: kernel-core%{_isa} = %{rpmver}
-Provides: kernel-core-%{rpmver} = %{kverstr}
-Provides: %{name}-core-%{rpmver} = %{kverstr}
-Provides:  kernel-drm-nouveau = 16
-# multiver
-Provides: %{name}%{_basekver}-core = %{rpmver}
-Requires: bash
-Requires: coreutils
-Requires: dracut
-Requires: linux-firmware
-Requires: /usr/bin/kernel-install
-Requires: kernel-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-%description core
-The kernel package contains the Linux kernel (vmlinuz), the core of any
-Linux operating system.  The kernel handles the basic functions
-of the operating system: memory allocation, process allocation, device
-input and output, etc.
-
-%package modules
-Summary: Kernel modules to match the core kernel
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel-module)
-Provides: %{name}%{_basekver}-modules = %{rpmver}
-Provides: kernel-modules = %{rpmver}
-Provides: kernel-modules%{_isa} = %{rpmver}
-Provides: kernel-modules-uname-r = %{kverstr}
-Provides: kernel-modules-%{_arch} = %{rpmver}
-Provides: kernel-modules-%{rpmver} = %{kverstr}
-Provides: %{name}-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-%description modules
-This package provides kernel modules for the core %{?flavor:%{flavor}} kernel package.
-
-%if %{_nv_build}
-%package nvidia-open
-Summary: Prebuilt nvidia-open kernel modules to match the core kernel
-Group: System Environment/Kernel
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: nvidia-kmod >= %{_nv_ver}
-Provides: installonlypkg(kernel-module)
-Conflicts: akmod-nvidia
-Recommends: xorg-x11-drv-nvidia >= %{_nv_ver}
-%description nvidia-open
-This package provides prebuilt nvidia-open kernel modules for the core %{?flavor:%{flavor}} kernel package.
-%endif
-
-%package headers
-Summary: Header files for the Linux kernel for use by glibc
-Group: Development/System
-Provides: kernel-headers = %{kverstr}
-Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers%{_isa} = %{kverstr}
-Obsoletes: kernel-headers < %{kverstr}
-Obsoletes: glibc-kernheaders < 3.0-46
-
-%description headers
-Kernel-headers includes the C header files that specify the interface
-between the Linux kernel and userspace libraries and programs.  The
-header files define structures and constants that are needed for
-building most standard programs and are also needed for rebuilding the
-glibc package.
-
-%package devel
-Summary: Development package for building kernel modules to match the %{?flavor:%{flavor}} kernel
-Group: System Environment/Kernel
-AutoReqProv: no
-Requires: findutils
-Requires: perl-interpreter
-Requires: openssl-devel
-Requires: flex
-Requires: make
-Requires: bison
-Requires: elfutils-libelf-devel
-Requires: gcc
-%if %{llvm_kbuild}
-Requires: clang
-Requires: llvm
-Requires: lld
-%endif
-Enhances: akmods
-Enhances: dkms
-Provides: installonlypkg(kernel)
-Provides: kernel-devel = %{rpmver}
-Provides: kernel-devel-uname-r = %{kverstr}
-Provides: kernel-devel-%{_arch} = %{rpmver}
-Provides: kernel-devel%{_isa} = %{rpmver}
-Provides: kernel-devel-%{rpmver} = %{kverstr}
-Provides: %{name}-devel-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver}-devel = %{rpmver}
-%description devel
-This package provides kernel headers and makefiles sufficient to build modules
-against the %{?flavor:%{flavor}} kernel package.
-
-%package devel-matched
-Summary: Meta package to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel
-Requires: %{name}-devel = %{rpmver},
-Requires: %{name}-core = %{rpmver}
-Provides: kernel-devel-matched = %{rpmver}
-Provides: kernel-devel-matched%{_isa} = %{rpmver}
-
-%description devel-matched
-This meta package is used to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel.
+    The meta package for %{name}.
 
 %prep
-%setup -q -n linux-%{_tarkver}
+    %setup -q %{?SOURCE10:-b 10} -n linux-%{_tarkver}
+    %autopatch -p1 -v -M 9
 
-tar -xzf %{SOURCE2} -C %{_builddir}
+    cp %{SOURCE1} .config
 
-# Apply CachyOS patch
-patch -p1 -i %{PATCH0}
+    # Default configs to always enable
+    # Enable CACHY sauce and the scheduler
+    # used in the default linux-cachyos kernel
+    scripts/config -e CACHY -e SCHED_BORE
 
-# Apply EEVDF and BORE patches
-patch -p1 -i %{PATCH1}
+    # Use SElinux by default
+    # https://github.com/sirlucjan/copr-linux-cachyos/pull/1
+    scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
-# Replace OpenSSL Engine API with Provider API
-patch -p1 -i %{PATCH2}
+    # Do not change the system's hostname
+    scripts/config -u DEFAULT_HOSTNAME
 
-### Apply patches for nvidia-open
-# Set modeset and fbdev to default enabled
-patch -p1 -i %{PATCH3} -d %{_builddir}/%{_nv_open_pkg}/kernel-open
-# Silence Assert warnings
-patch -p1 -i %{PATCH4} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix for Zen5 error print in dmesg
-patch -p1 -i %{PATCH5} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix HDMI Names
-patch -p1 -i %{PATCH6} -d %{_builddir}/%{_nv_open_pkg}/
+    case %{_hz_tick} in
+        100|250|300|500|600|750|1000)
+            scripts/config -e HZ_%{_hz_tick} --set-val HZ %{_hz_tick};;
+        *)
+            echo "Invalid tickrate value, using default 1000"
+            scripts/config -e HZ_1000 --set-val HZ 1000;;
+    esac
 
-# Fetch the config and move it to the proper directory
-cp %{SOURCE1} .config
+    %if %{_x86_64_lvl} < 5 && %{_x86_64_lvl} > 0
+        scripts/config --set-val X86_64_VERSION %{_x86_64_lvl}
+    %else
+        echo "Invalid x86_64 ISA Level. Using x86_64_v3"
+        scripts/config --set-val X86_64_VERSION 3
+    %endif
 
-# Remove CachyOS's localversion
-find . -name "localversion*" -delete
-scripts/config -u LOCALVERSION
+    %if %{_build_lto}
+        scripts/config -e LTO_CLANG_THIN
+    %endif
 
-# Enable CachyOS tweaks
-scripts/config -e CACHY
+    %if %{_build_minimal}
+        %make_build LSMOD=%{SOURCE2} localmodconfig
+    %else
+        %make_build olddefconfig
+    %endif
 
-# Enable BORE Scheduler
-scripts/config -e SCHED_BORE
+    diff -u %{SOURCE1} .config || :
 
-# Setting tick rate
-scripts/config -d HZ_300
-scripts/config -e HZ_1000
-scripts/config --set-val HZ 1000
-
-# Disable DEBUG
-scripts/config -d DEBUG_INFO
-scripts/config -d DEBUG_INFO_BTF
-scripts/config -d DEBUG_INFO_DWARF4
-scripts/config -d DEBUG_INFO_DWARF5
-scripts/config -d PAHOLE_HAS_SPLIT_BTF
-scripts/config -d DEBUG_INFO_BTF_MODULES
-scripts/config -d SLUB_DEBUG
-scripts/config -d PM_DEBUG
-scripts/config -d PM_ADVANCED_DEBUG
-scripts/config -d PM_SLEEP_DEBUG
-scripts/config -d ACPI_DEBUG
-scripts/config -d SCHED_DEBUG
-scripts/config -d LATENCYTOP
-scripts/config -d DEBUG_PREEMPT
-
-# Enable x86_64_v2
-# Just to be sure, check:
-# /lib/ld-linux-x86-64.so.2 --help | grep supported
-# and make sure if your processor supports it:
-# x86-64-v2 (supported, searched)
-scripts/config --set-val X86_64_VERSION 2
-
-# Set O3
-scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE
-scripts/config -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
-
-# Enable full ticks
-scripts/config -d HZ_PERIODIC
-scripts/config -d NO_HZ_IDLE
-scripts/config -d CONTEXT_TRACKING_FORCE
-scripts/config -e NO_HZ_FULL_NODEF
-scripts/config -e NO_HZ_FULL
-scripts/config -e NO_HZ
-scripts/config -e NO_HZ_COMMON
-scripts/config -e CONTEXT_TRACKING
-
-# Enable full preempt
-scripts/config -e PREEMPT_BUILD
-scripts/config -d PREEMPT_NONE
-scripts/config -d PREEMPT_VOLUNTARY
-scripts/config -e PREEMPT
-scripts/config -e PREEMPT_COUNT
-scripts/config -e PREEMPTION
-scripts/config -e PREEMPT_DYNAMIC
-
-# Enable thin lto
-%if %{llvm_kbuild}
-scripts/config -e LTO
-scripts/config -e LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG_THIN
-scripts/config -d LTO_NONE
-scripts/config -e HAS_LTO_CLANG
-scripts/config -d LTO_CLANG_FULL
-scripts/config -e LTO_CLANG_THIN
-scripts/config -e HAVE_GCC_PLUGINS
-%endif
-
-# Unset hostname
-scripts/config -u DEFAULT_HOSTNAME
-
-# Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
-
-# Set kernel version string as build salt
-scripts/config --set-str BUILD_SALT "%{kverstr}"
-
-# Finalize the patched config
-#make %{?_smp_mflags} EXTRAVERSION=-%{krelstr} oldconfig
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr} olddefconfig
-
-# Save configuration for later reuse
-cat .config > config-linux-bore
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}/kernel-open
+        %patch -P 10 -p1
+        cd ..
+        %autopatch -p1 -v -m 11 -M 19
+    %endif
 
 %build
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr}
-%if %{llvm_kbuild}
-clang ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%else
-gcc ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%endif
+    %make_build EXTRAVERSION=-%{release}.%{_arch} all
+    %make_build -C tools/bpf/bpftool vmlinux.h feature-clang-bpf-co-re=1
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-CFLAGS= CXXFLAGS= LDFLAGS= make %{?llvm_build_env_vars} KERNEL_UNAME=%{kverstr} IGNORE_PREEMPT_RT_PRESENCE=1 IGNORE_CC_MISMATCH=yes SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver} %{?_smp_mflags} modules
-%endif
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        CFLAGS= CXXFLAGS= LDFLAGS= %make_build %{_module_args} IGNORE_CC_MISMATCH=yes modules
+    %endif
 
 %install
+    echo "Installing the kernel image..."
+    install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
+    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
 
-ImageName=$(make image_name | tail -n 1)
+    echo "Installing kernel modules..."
+    ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
 
-mkdir -p %{buildroot}/boot
+    echo "Installing files for the development package..."
+    install -Dt %{buildroot}%{_devel_dir} -m644 .config Makefile Module.symvers System.map tools/bpf/bpftool/vmlinux.h
+    cp .config %{buildroot}%{_kernel_dir}/config
+    cp System.map %{buildroot}%{_kernel_dir}/System.map
+    cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts
+    rm -rf %{buildroot}%{_devel_dir}/include
+    cp -a scripts %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts/tracing
+    rm -f %{buildroot}%{_devel_dir}/scripts/spdxcheck.py
 
-cp -v $ImageName %{buildroot}/boot/vmlinuz-%{kverstr}
-chmod 755 %{buildroot}/boot/vmlinuz-%{kverstr}
+    # The cp commands below are needed for parity with Fedora's packaging
+    # Install files that are needed for `make scripts` to succeed
+    cp -a --parents security/selinux/include/classmap.h %{buildroot}%{_devel_dir}
+    cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}%{_devel_dir}
 
-ZSTD_CLEVEL=19 make %{?_smp_mflags} INSTALL_MOD_PATH=%{buildroot} modules_install mod-fw=
-make %{?_smp_mflags} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
+    # Install files that are needed for `make prepare` to succeed -- Generic
+    cp -a --parents tools/include/linux/compiler* %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux/types.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/build/Build.include %{buildroot}%{_devel_dir}
+    cp --parents tools/build/fixdep.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/sync-check.sh %{buildroot}%{_devel_dir}
+    cp -a --parents tools/bpf/resolve_btfids %{buildroot}%{_devel_dir}
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-install -dm755 "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -Dt "%{buildroot}/usr/share/licenses/nvidia-open" -m644 COPYING
-find "%{buildroot}" -name '*.ko' -exec zstd --rm -19 {} +
-%endif
+    cp --parents security/selinux/include/policycap_names.h %{buildroot}%{_devel_dir}
+    cp --parents security/selinux/include/policycap.h %{buildroot}%{_devel_dir}
 
-# prepare -devel files
-### all of the things here are derived from the Fedora kernel.spec
-### see
-##### https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec
-cd %{_builddir}/linux-%{_tarkver}
-rm -f %{buildroot}/lib/modules/%{kverstr}/build
-rm -f %{buildroot}/lib/modules/%{kverstr}/source
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build
-(cd %{buildroot}/lib/modules/%{kverstr} ; ln -s build source)
-# dirs for additional modules per module-init-tools, kbuild/modules.txt
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/updates
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/weak-updates
-# CONFIG_KERNEL_HEADER_TEST generates some extra files in the process of
-# testing so just delete
-find . -name *.h.s -delete
-# first copy everything
-cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}/lib/modules/%{kverstr}/build
-if [ ! -e Module.symvers ]; then
-touch Module.symvers
-fi
-cp Module.symvers %{buildroot}/lib/modules/%{kverstr}/build
-cp System.map %{buildroot}/lib/modules/%{kverstr}/build
-if [ -s Module.markers ]; then
-cp Module.markers %{buildroot}/lib/modules/%{kverstr}/build
-fi
+    cp -a --parents tools/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/vdso %{buildroot}%{_devel_dir}
+    cp --parents tools/scripts/utilities.mak %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/subcmd %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/*.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/*.[ch] %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/Build %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/include/objtool/*.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/bpf %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/bpf/Build %{buildroot}%{_devel_dir}
 
-# create the kABI metadata for use in packaging
-# NOTENOTE: the name symvers is used by the rpm backend
-# NOTENOTE: to discover and run the /usr/lib/rpm/fileattrs/kabi.attr
-# NOTENOTE: script which dynamically adds exported kernel symbol
-# NOTENOTE: checksums to the rpm metadata provides list.
-# NOTENOTE: if you change the symvers name, update the backend too
-echo "**** GENERATING kernel ABI metadata ****"
-gzip -c9 < Module.symvers > %{buildroot}/boot/symvers-%{kverstr}.gz
-cp %{buildroot}/boot/symvers-%{kverstr}.gz %{buildroot}/lib/modules/%{kverstr}/symvers.gz
+    # Misc headers
+    cp -a --parents arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a include %{buildroot}%{_devel_dir}/include
+    cp -a sound/soc/sof/sof-audio.h %{buildroot}%{_devel_dir}/sound/soc/sof
+    cp -a tools/objtool/objtool %{buildroot}%{_devel_dir}/tools/objtool/
+    cp -a tools/objtool/fixdep %{buildroot}%{_devel_dir}/tools/objtool/
 
-# then drop all but the needed Makefiles/Kconfig files
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/include
-cp .config %{buildroot}/lib/modules/%{kverstr}/build
-cp -a scripts %{buildroot}/lib/modules/%{kverstr}/build
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts/tracing
-rm -f %{buildroot}/lib/modules/%{kverstr}/build/scripts/spdxcheck.py
+    # Install files that are needed for `make prepare` to succeed -- for x86_64
+    cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/stack.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/ctype.h %{buildroot}%{_devel_dir}
 
-%ifarch s390x
-# CONFIG_EXPOLINE_EXTERN=y produces arch/s390/lib/expoline/expoline.o
-# which is needed during external module build.
-if [ -f arch/s390/lib/expoline/expoline.o ]; then
-cp -a --parents arch/s390/lib/expoline/expoline.o %{buildroot}/lib/modules/%{kverstr}/build
-fi
-%endif
+    cp -a --parents scripts/syscalltbl.sh %{buildroot}%{_devel_dir}
+    cp -a --parents scripts/syscallhdr.sh %{buildroot}%{_devel_dir}
 
-# Files for 'make scripts' to succeed with kernel-devel.
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/security/selinux/include
-cp -a --parents security/selinux/include/classmap.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}/lib/modules/%{kverstr}/build
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/tools/include/tools
-cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
+    cp -a --parents tools/arch/x86/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/lib %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/lib/ %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/ %{buildroot}%{_devel_dir}
 
-# Files for 'make prepare' to succeed with kernel-devel.
-cp -a --parents tools/include/linux/compiler* %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux/types.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/build/Build.include %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/fixdep.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/sync-check.sh %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/bpf/resolve_btfids %{buildroot}/lib/modules/%{kverstr}/build
+    # Final cleanups ala Fedora
+    echo "Cleaning up development files..."
+    find %{buildroot}%{_devel_dir}/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    find %{buildroot}%{_devel_dir}/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    touch -r %{buildroot}%{_devel_dir}/Makefile \
+        %{buildroot}%{_devel_dir}/include/generated/uapi/linux/version.h \
+        %{buildroot}%{_devel_dir}/include/config/auto.conf
 
-cp --parents security/selinux/include/policycap_names.h %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents security/selinux/include/policycap.h %{buildroot}/lib/modules/%{kverstr}/build
+    # These links will be owned by the modules package, creating a broken
+    # link unless the -devel package is installed. why??
+    rm -rf %{buildroot}%{_kernel_dir}/build
+    ln -s %{_devel_dir} %{buildroot}%{_kernel_dir}/build
+    ln -s %{_kernel_dir}/build %{buildroot}%{_kernel_dir}/source
 
-cp -a --parents tools/include/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/vdso %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/scripts/utilities.mak %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/subcmd %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/*.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/*.[ch] %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/include/objtool/*.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/bpf %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/bpf/Build %{buildroot}/lib/modules/%{kverstr}/build
+    # Create stub initramfs to inflate disk space requirements.
+    # This should hopefully prevent some initramfs failures due to
+    # insufficient space in /boot (#bz #530778)
+    # 90 seems to be a safe value nowadays. It is slightly inflated than the
+    # measured average to also account for installed vmlinuz in /boot
+    echo "Creating stub initramfs..."
+    install -dm755 %{buildroot}/boot
+    dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{_kver}.img bs=1M count=90
 
-if [ -f tools/objtool/objtool ]; then
-  cp -a tools/objtool/objtool %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -f tools/objtool/fixdep ]; then
-  cp -a tools/objtool/fixdep %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -d arch/%{karch}/scripts ]; then
-  cp -a arch/%{karch}/scripts %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch} || :
-fi
-if [ -f arch/%{karch}/*lds ]; then
-  cp -a arch/%{karch}/*lds %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch}/ || :
-fi
-if [ -f arch/%{asmarch}/kernel/module.lds ]; then
-  cp -a --parents arch/%{asmarch}/kernel/module.lds %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-find %{buildroot}/lib/modules/%{kverstr}/build/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-%ifarch ppc64le
-cp -a --parents arch/powerpc/lib/crtsavres.[So] %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-if [ -d arch/%{asmarch}/include ]; then
-  cp -a --parents arch/%{asmarch}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-%ifarch aarch64
-# arch/arm64/include/asm/xen references arch/arm
-cp -a --parents arch/arm/include/asm/xen %{buildroot}/lib/modules/%{kverstr}/build/
-# arch/arm64/include/asm/opcodes.h references arch/arm
-cp -a --parents arch/arm/include/asm/opcodes.h %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-# include the machine specific headers for ARM variants, if available.
-%ifarch %{arm}
-if [ -d arch/%{asmarch}/mach-${Variant}/include ]; then
-  cp -a --parents arch/%{asmarch}/mach-${Variant}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-# include a few files for 'make prepare'
-cp -a --parents arch/arm/tools/gen-mach-types %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/arm/tools/mach-types %{buildroot}/lib/modules/%{kverstr}/build/
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        echo "Installing NVIDIA open kernel modules..."
+        install -Dt %{buildroot}%{_kernel_dir}/nvidia -m644 kernel-open/*.ko
+        find %{buildroot}%{_kernel_dir}/nvidia -name '*.ko' -exec zstd --rm -19 {} +
+        install -Dt %{buildroot}/%{_defaultlicensedir}/%{name}-nvidia-open -m644 COPYING
+    %endif
 
-%endif
-cp -a include %{buildroot}/lib/modules/%{kverstr}/build/include
+%package core
+Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
+AutoReq:        no
+Conflicts:      xfsprogs < 4.3.0-1
+Conflicts:      xorg-x11-drv-vmmouse < 13.0.99
+Provides:       kernel = %{_rpmver}
+Provides:       kernel-core-uname-r = %{_kver}
+Provides:       kernel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires(pre):  /usr/bin/kernel-install
+Requires(pre):  coreutils
+Requires(pre):  dracut >= 027
+Requires(pre):  systemd >= 203-2
+Requires(pre):  ((linux-firmware >= 20150904-56.git6ebf5d57) if linux-firmware)
+Requires(preun):systemd >= 200
+Recommends:     linux-firmware
 
-%ifarch i686 x86_64
-# files for 'make prepare' to succeed with kernel-devel
-cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/stack.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/ctype.h %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents scripts/syscalltbl.sh %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents scripts/syscallhdr.sh %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents tools/arch/x86/include/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/lib %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/lib/ %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/ %{buildroot}/lib/modules/%{kverstr}/build
-
-%endif
-# Clean up intermediate tools files
-find %{buildroot}/lib/modules/%{kverstr}/build/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-
-# Make sure the Makefile, version.h, and auto.conf have a matching
-# timestamp so that external modules can be built
-touch -r %{buildroot}/lib/modules/%{kverstr}/build/Makefile \
-%{buildroot}/lib/modules/%{kverstr}/build/include/generated/uapi/linux/version.h \
-%{buildroot}/lib/modules/%{kverstr}/build/include/config/auto.conf
-
-find %{buildroot}/lib/modules/%{kverstr} -name "*.ko" -type f >modnames
-
-# mark modules executable so that strip-to-file can strip them
-xargs --no-run-if-empty chmod u+x < modnames
-
-# Generate a list of modules for block and networking.
-
-grep -F /drivers/ modnames | xargs --no-run-if-empty nm -upA |
-sed -n 's,^.*/\([^/]*\.ko\):  *U \(.*\)$,\1 \2,p' > drivers.undef
-
-collect_modules_list()
-{
-  sed -r -n -e "s/^([^ ]+) \\.?($2)\$/\\1/p" drivers.undef |
-LC_ALL=C sort -u > %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  if [ ! -z "$3" ]; then
-sed -r -e "/^($3)\$/d" -i %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  fi
-}
-
-collect_modules_list networking \
-  'register_netdev|ieee80211_register_hw|usbnet_probe|phy_driver_register|rt(l_|2x00)(pci|usb)_probe|register_netdevice'
-collect_modules_list block \
-  'ata_scsi_ioctl|scsi_add_host|scsi_add_host_with_dma|blk_alloc_queue|blk_init_queue|register_mtd_blktrans|scsi_esp_register|scsi_register_device_handler|blk_queue_physical_block_size' 'pktcdvd.ko|dm-mod.ko'
-collect_modules_list drm \
-  'drm_open|drm_init'
-collect_modules_list modesetting \
-  'drm_crtc_init'
-
-# detect missing or incorrect license tags
-( find %{buildroot}/lib/modules/%{kverstr} -name '*.ko' | xargs /sbin/modinfo -l | \
-grep -E -v 'GPL( v2)?$|Dual BSD/GPL$|Dual MPL/GPL$|GPL and additional rights$' ) && exit 1
-
-remove_depmod_files()
-{
-# remove files that will be auto generated by depmod at rpm -i time
-pushd %{buildroot}/lib/modules/%{kverstr}/
-rm -f modules.{alias,alias.bin,builtin.alias.bin,builtin.bin} \
-  modules.{dep,dep.bin,devname,softdep,symbols,symbols.bin}
-popd
-}
-
-remove_depmod_files
-
-mkdir -p %{buildroot}%{_prefix}/src/kernels
-mv %{buildroot}/lib/modules/%{kverstr}/build %{buildroot}%{_prefix}/src/kernels/%{kverstr}
-
-# This is going to create a broken link during the build, but we don't use
-# it after this point.  We need the link to actually point to something
-# when kernel-devel is installed, and a relative link doesn't work across
-# the F17 UsrMove feature.
-ln -sf %{_prefix}/src/kernels/%{kverstr} %{buildroot}/lib/modules/%{kverstr}/build
-
-find %{buildroot}%{_prefix}/src/kernels -name ".*.cmd" -delete
-#
-
-cp -v System.map %{buildroot}/boot/System.map-%{kverstr}
-cp -v System.map %{buildroot}/lib/modules/%{kverstr}/System.map
-cp -v .config %{buildroot}/boot/config-%{kverstr}
-cp -v .config %{buildroot}/lib/modules/%{kverstr}/config
-
-(cd "%{buildroot}/boot/" && sha512hmac "vmlinuz-%{kverstr}" > ".vmlinuz-%{kverstr}.hmac")
-
-cp -v  %{buildroot}/boot/vmlinuz-%{kverstr} %{buildroot}/lib/modules/%{kverstr}/vmlinuz
-(cd "%{buildroot}/lib/modules/%{kverstr}" && sha512hmac vmlinuz > .vmlinuz.hmac)
-
-# create dummy initramfs image to inflate the disk space requirement for the initramfs. 48M seems to be the right size nowadays with more and more hardware requiring initramfs-located firmware to work properly (for reference, Fedora has it set to 20M)
-dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{kverstr}.img bs=1M count=48
-
-%clean
-rm -rf %{buildroot}
+%description core
+    The kernel package contains the Linux kernel (vmlinuz), the core of any
+    Linux operating system.  The kernel handles the basic functions
+    of the operating system: memory allocation, process allocation, device
+    input and output, etc.
 
 %post core
-if [ `uname -i` == "x86_64" -o `uname -i` == "i386" ] &&
-   [ -f /etc/sysconfig/kernel ]; then
-  /bin/sed -r -i -e 's/^DEFAULTKERNEL=kernel-smp$/DEFAULTKERNEL=kernel/' /etc/sysconfig/kernel || exit $?
-fi
-if [ -x /bin/kernel-install ] && [ -d /boot ]; then
-/bin/kernel-install add %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-fi
+    mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+    touch %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
 
 %posttrans core
-if [ ! -z $(rpm -qa | grep grubby) ]; then
-  grubby --set-default="/boot/vmlinuz-%{kverstr}"
-fi
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
+        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
+            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+            if command -v restorecon &>/dev/null; then
+                restorecon "/boot/symvers-%{_kver}.zst"
+            fi
+        fi
+    fi
 
 %preun core
-/bin/kernel-install remove %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-if [ -x /usr/sbin/weak-modules ]
-then
-/usr/sbin/weak-modules --remove-kernel %{kverstr} || exit $?
-fi
-
-%post devel
-if [ -f /etc/sysconfig/kernel ]
-then
-. /etc/sysconfig/kernel || exit $?
-fi
-if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]
-then
-(cd /usr/src/kernels/%{kverstr} &&
- /usr/bin/find . -type f | while read f; do
-   hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f 2>&1 >/dev/null
- done)
-fi
-
-%post modules
-/sbin/depmod -a %{kverstr}
-
-%if %{_nv_build}
-%posttrans nvidia-open
-/sbin/depmod -a %{kverstr}
-%endif
+    /bin/kernel-install remove %{_kver} || exit $?
+    if [ -x /usr/sbin/weak-modules ]; then
+        /usr/sbin/weak-modules --remove-kernel %{_kver} || exit $?
+    fi
 
 %files core
-%ghost %attr(0600, root, root) /boot/vmlinuz-%{kverstr}
-%ghost %attr(0600, root, root) /boot/System.map-%{kverstr}
-%ghost %attr(0600, root, root) /boot/initramfs-%{kverstr}.img
-%ghost %attr(0600, root, root) /boot/symvers-%{kverstr}.gz
-%ghost %attr(0644, root, root) /boot/config-%{kverstr}
-/boot/.vmlinuz-%{kverstr}.hmac
-%dir /lib/modules/%{kverstr}/
-/lib/modules/%{kverstr}/.vmlinuz.hmac
-/lib/modules/%{kverstr}/config
-/lib/modules/%{kverstr}/vmlinuz
-/lib/modules/%{kverstr}/System.map
-/lib/modules/%{kverstr}/symvers.gz
+    %dir %{_kernel_dir}
+    %license COPYING
+    %ghost /boot/initramfs-%{_kver}.img
+    %{_kernel_dir}/vmlinuz
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
+    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/config
+    %{_kernel_dir}/System.map
+
+%package modules
+Summary:        Kernel modules package for %{name}
+Provides:       kernel-modules = %{_rpmver}
+Provides:       kernel-modules-core = %{_rpmver}
+Provides:       kernel-modules-uname-r = %{_kver}
+Provides:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+
+%description modules
+    This package provides kernel modules for the %{name}-core kernel package.
+
+%post modules
+    /sbin/depmod -a %{_kver}
+    if [ ! -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver} ]; then
+        mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+        touch %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    fi
+
+%posttrans modules
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        if [ -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver} ]; then
+            echo "Running: dracut -f --kver %{_kver}"
+            dracut -f --kver "%{_kver}" || exit $?
+        fi
+    fi
+
+%postun modules
+    /sbin/depmod -a %{_kver}
 
 %files modules
-/lib/modules/%{kverstr}/
-%exclude /lib/modules/%{kverstr}/.vmlinuz.hmac
-%exclude /lib/modules/%{kverstr}/config
-%exclude /lib/modules/%{kverstr}/vmlinuz
-%exclude /lib/modules/%{kverstr}/System.map
-%exclude /lib/modules/%{kverstr}/symvers.gz
-%exclude /lib/modules/%{kverstr}/build
-%exclude /lib/modules/%{kverstr}/source
-%if %{_nv_build}
-%exclude /lib/modules/%{kverstr}/nvidia
+    %{_kernel_dir}/modules.order
+    %{_kernel_dir}/build
+    %{_kernel_dir}/source
+    %{_kernel_dir}/kernel
 
-%files nvidia-open
-/lib/modules/%{kverstr}/nvidia
-/usr/share/licenses/nvidia-open/COPYING
+%package devel
+Summary:        Development package for building kernel modules to match %{name}
+Provides:       kernel-devel = %{_rpmver}
+Provides:       kernel-devel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+AutoReqProv:    no
+Requires(pre):  findutils
+Requires:       findutils
+Requires:       perl-interpreter
+Requires:       openssl-devel
+Requires:       elfutils-libelf-devel
+Requires:       bison
+Requires:       flex
+Requires:       make
+
+%if %{_build_lto}
+Requires:       clang
+Requires:       lld
+Requires:       llvm
+%else
+Requires:       gcc
 %endif
 
-%files headers
-%defattr (-, root, root)
-/usr/include/*
+%description devel
+    This package provides kernel headers and makefiles sufficient to build modules against %{name}.
+
+%post devel
+    if [ -f /etc/sysconfig/kernel ]; then
+        . /etc/sysconfig/kernel || exit $?
+    fi
+    if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]; then
+        (cd /usr/src/kernels/%{_kver} &&
+        /usr/bin/find . -type f | while read f; do
+            hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f > /dev/null
+        done;
+        )
+    fi
 
 %files devel
-%defattr (-, root, root)
-/usr/src/kernels/%{kverstr}
-/lib/modules/%{kverstr}/build
-/lib/modules/%{kverstr}/source
+    %{_devel_dir}
+
+%package devel-matched
+Summary:        Meta package to install matching core and devel packages for %{name}
+Provides:       kernel-devel-matched = %{_rpmver}
+Requires:       %{name}-core = %{_rpmver}
+Requires:       %{name}-devel = %{_rpmver}
+
+%description devel-matched
+    This meta package is used to install matching core and devel packages for %{name}.
 
 %files devel-matched
 
+%if %{_build_nv}
+%package nvidia-open
+Summary:        nvidia-open %{_nv_ver} kernel modules for %{name}
+Provides:       nvidia-kmod >= %{_nv_ver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+Conflicts:      akmod-nvidia
+Recommends:     xorg-x11-drv-nvidia >= %{_nv_ver}
+
+%description nvidia-open
+    This package provides nvidia-open %{_nv_ver} kernel modules for %{name}.
+
+%post nvidia-open
+    /sbin/depmod -a %{_kver}
+
+%files nvidia-open
+    %license %{_defaultlicensedir}/%{name}-nvidia-open/COPYING
+    %{_kernel_dir}/nvidia
+%endif
+
 %files
+
+

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos-lts%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachylts1%{?_lto_args:.lto}%{?dist}
+Release:        cachylts2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -366,8 +366,6 @@ Recommends:     linux-firmware
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
-    %{_kernel_dir}/modules.builtin
-    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/symvers.zst
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
@@ -400,10 +398,9 @@ Requires:       kernel-uname-r = %{_kver}
         fi
     fi
 
-%postun modules
-    /sbin/depmod -a %{_kver}
-
 %files modules
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/modules.order
     %{_kernel_dir}/build
     %{_kernel_dir}/source

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -1,728 +1,486 @@
-### A port of linux-cachyos-lts (https://github.com/CachyOS/linux-cachyos/tree/master/linux-cachyos-lts) for the Fedora operating system.
-# https://github.com/CachyOS/linux-cachyos
-### The authors of linux-cachyos patchset:
-# Peter Jung ptr1337 <admin@ptr1337.dev>
-# Piotr Gorski sirlucjan <piotrgorski@cachyos.org>
-### The author of BORE-EEVDF Scheduler:
-# Masahito Suzuki <firelzrd@gmail.com>
-### The port maintainer for Fedora:
-# bieszczaders <zbyszek@linux.pl>
-# https://copr.fedorainfracloud.org/coprs/bieszczaders/
+# Maintainer: Eric Naim <dnaim@cachyos.org>
 
-%define _build_id_links none
+# Fedora bits
+%define __spec_install_post %{__os_install_post}
+%define _default_patch_fuzz 2
 %define _disable_source_fetch 0
-
-# See https://fedoraproject.org/wiki/Changes/SetBuildFlagsBuildCheck to why this has to be done
-%if 0%{?fedora} >= 37
-%undefine _auto_set_build_flags
-%endif
-
-%ifarch x86_64
-%define karch x86
-%define asmarch x86
-%endif
-
-# define git branch to make testing easier without merging to master branch
-%define _git_branch master
-
-# whether to build kernel with llvm compiler(clang)
-%define llvm_kbuild 0
-%if %{llvm_kbuild}
-%define llvm_build_env_vars CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
-%define ltoflavor 1
-%endif
-
-%define flavor cachyos-lts
-Name: kernel%{?flavor:-%{flavor}}%{?ltoflavor:-lto}
-Summary: The Linux Kernel with Cachyos-LTS Patches
-
-%define _basekver 6.6
-%define _stablekver 71
-%if %{_stablekver} == 0
-%define _tarkver %{_basekver}
-%else
-%define _tarkver %{_basekver}.%{_stablekver}
-%endif
-
-Version: %{_basekver}.%{_stablekver}
-
-%define customver 1
-%define flaver clts%{customver}
-
-Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
-
-# Define rawhide fedora version
-%define _rawhidever 42
-
-# Build nvidia-open alongside the kernel
-%define _nv_build 1
-%if 0%{?fedora} >= 41
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%else
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%endif
-%define _nv_open_pkg open-gpu-kernel-modules-%{_nv_ver}
-
-%define rpmver %{version}-%{release}
-%define krelstr %{release}.%{_arch}
-%define kverstr %{version}-%{krelstr}
-
-License: GPLv2 and Redistributable, no modifications permitted
-Group: System Environment/Kernel
-Vendor: The Linux Community and CachyOS maintainer(s)
-URL: https://cachyos.org
-Source0: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
-Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-lts/config
-Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
-# Stable patches
-Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
-Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/0001-openssl-provider.patch
-
-Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled.patch
-Patch4: %{_nvidia_patchurl}/0006-silence-event-assert-until-570.patch
-Patch5: %{_nvidia_patchurl}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
-Patch6: %{_nvidia_patchurl}/0009-fix-hdmi-names.patch
-# Dev patches
-#Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all-dev.patch
-#Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched-dev/0001-bore-cachy.patch
-%define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
-BuildRequires: python3-devel
-BuildRequires: make
-BuildRequires: perl-generators
-BuildRequires: perl-interpreter
-BuildRequires: openssl-devel
-BuildRequires: bison
-BuildRequires: flex
-BuildRequires: findutils
-BuildRequires: git-core
-BuildRequires: perl-devel
-BuildRequires: openssl
-BuildRequires: elfutils-devel
-BuildRequires: gawk
-BuildRequires: binutils
-BuildRequires: m4
-BuildRequires: tar
-BuildRequires: hostname
-BuildRequires: bzip2
-BuildRequires: bash
-BuildRequires: gzip
-BuildRequires: xz
-BuildRequires: bc
-BuildRequires: diffutils
-BuildRequires: redhat-rpm-config
-BuildRequires: net-tools
-BuildRequires: elfutils
-BuildRequires: patch
-BuildRequires: rpm-build
-BuildRequires: dwarves
-BuildRequires: kmod
-BuildRequires: libkcapi-hmaccalc
-BuildRequires: perl-Carp
-BuildRequires: rsync
-BuildRequires: grubby
-BuildRequires: wget
-BuildRequires: gcc
-BuildRequires: gcc-c++
-%if %{llvm_kbuild}
-BuildRequires: llvm
-BuildRequires: clang
-BuildRequires: lld
-%endif
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
+%define make_build make %{?_lto_args} %{?_smp_mflags}
+%undefine __brp_mangle_shebangs
+%undefine _auto_set_build_flags
+%undefine _include_frame_pointers
 
+# Linux Kernel Versions
+%define _basekver 6.12
+%define _stablekver 10
+%define _rpmver %{version}-%{release}
+%define _kver %{_rpmver}.%{_arch}
+
+%if %{_stablekver} == 0
+    %define _tarkver %{_basekver}
+%else
+    %define _tarkver %{version}
+%endif
+
+# Build a minimal a kernel via modprobed.db
+# file to reduce build times
+%define _build_minimal 0
+
+# Builds the kernel with clang and enables
+# ThinLTO
+%define _build_lto 0
+
+# Builds nvidia-open kernel modules with
+# the kernel
+%define _build_nv 1
+%define _nv_ver 565.77
+%define _nv_pkg open-gpu-kernel-modules-%{_nv_ver}
+
+# Define the tickrate used by the kernel
+# Valid values: 100, 250, 300, 500, 600, 750 and 1000
+# An invalid value will not fail and continue to use
+# 1000Hz tickrate
+%define _hz_tick 1000
+
+# Defines the x86_64 ISA level used
+# to compile the kernel
+# Valid values are 1-4
+# An invalid value will continue and use
+# x86_64_v3
+%define _x86_64_lvl 3
+
+# Define variables for directory paths
+# to be used during packaging
+%define _kernel_dir /lib/modules/%{_kver}
+%define _devel_dir %{_usrsrc}/kernels/%{_kver}
+
+%define _patch_src https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}
+
+%if %{_build_lto}
+    # Define build environment variables to build the kernel with clang
+    %define _lto_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
+%endif
+
+%define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver}
+
+Name:           kernel-cachyos-lts%{?_lto_args:-lto}
+Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
+Version:        %{_basekver}.%{_stablekver}
+Release:        cachylts1%{?_lto_args:.lto}%{?dist}
+License:        GPL-2.0-only
+URL:            https://cachyos.org
+
+Requires:       kernel-core-uname-r = %{_kver}
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+
+BuildRequires:  bc
+BuildRequires:  bison
+BuildRequires:  dwarves
+BuildRequires:  elfutils-devel
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  gettext-devel
+BuildRequires:  kmod
+BuildRequires:  make
+BuildRequires:  openssl
+BuildRequires:  openssl-devel
+BuildRequires:  perl-Carp
+BuildRequires:  perl-devel
+BuildRequires:  perl-generators
+BuildRequires:  perl-interpreter
+BuildRequires:  python3-devel
+BuildRequires:  python3-pyyaml
+BuildRequires:  python-srpm-macros
+
+%if %{_build_lto}
+BuildRequires:  clang
+BuildRequires:  lld
+BuildRequires:  llvm
+%endif
+
+%if %{_build_nv}
+BuildRequires:  gcc-c++
+%endif
+
+# Indexes 0-9 are reserved for the kernel. 10-19 will be reserved for NVIDIA
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
+Source1:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-lts/config
+
+%if %{_build_minimal}
+# The default modprobed.db provided is used for linux-cachyos CI.
+# This should not be used for production and ideally should only be used for compile tests.
+# Note that any modprobed.db file is accepted
+Source2:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/modprobed.db
+%endif
+
+%if %{_build_nv}
+Source10:       https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_pkg}.tar.gz
+%endif
+
+Patch0:         %{_patch_src}/all/0001-cachyos-base-all.patch
+Patch1:         %{_patch_src}/sched/0001-bore-cachy.patch
+
+%if %{_build_lto}
+Patch2:         %{_patch_src}/misc/dkms-clang.patch
+%endif
+
+%if %{_build_nv}
+Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch
+Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
+Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
+Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+%endif
 
 %description
-The kernel-%{flaver} meta package
-
-%package core
-Summary: Kernel core package
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel)
-Provides: kernel = %{rpmver}
-Provides: kernel-core = %{rpmver}
-Provides: kernel-core-uname-r = %{kverstr}
-Provides: kernel-uname-r = %{kverstr}
-Provides: kernel-%{_arch} = %{rpmver}
-Provides: kernel-core%{_isa} = %{rpmver}
-Provides: kernel-core-%{rpmver} = %{kverstr}
-Provides: %{name}-core-%{rpmver} = %{kverstr}
-Provides:  kernel-drm-nouveau = 16
-# multiver
-Provides: %{name}%{_basekver}-core = %{rpmver}
-Requires: bash
-Requires: coreutils
-Requires: dracut
-Requires: linux-firmware
-Requires: /usr/bin/kernel-install
-Requires: kernel-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-%description core
-The kernel package contains the Linux kernel (vmlinuz), the core of any
-Linux operating system.  The kernel handles the basic functions
-of the operating system: memory allocation, process allocation, device
-input and output, etc.
-
-%package modules
-Summary: Kernel modules to match the core kernel
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel-module)
-Provides: %{name}%{_basekver}-modules = %{rpmver}
-Provides: kernel-modules = %{rpmver}
-Provides: kernel-modules%{_isa} = %{rpmver}
-Provides: kernel-modules-uname-r = %{kverstr}
-Provides: kernel-modules-%{_arch} = %{rpmver}
-Provides: kernel-modules-%{rpmver} = %{kverstr}
-Provides: %{name}-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-%description modules
-This package provides kernel modules for the core %{?flavor:%{flavor}} kernel package.
-
-%if %{_nv_build}
-%package nvidia-open
-Summary: Prebuilt nvidia-open kernel modules to match the core kernel
-Group: System Environment/Kernel
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: nvidia-kmod >= %{_nv_ver}
-Provides: installonlypkg(kernel-module)
-Conflicts: akmod-nvidia
-Recommends: xorg-x11-drv-nvidia >= %{_nv_ver}
-%description nvidia-open
-This package provides prebuilt nvidia-open kernel modules for the core %{?flavor:%{flavor}} kernel package.
-%endif
-
-%package headers
-Summary: Header files for the Linux kernel for use by glibc
-Group: Development/System
-Provides: kernel-headers = %{kverstr}
-Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers%{_isa} = %{kverstr}
-Obsoletes: kernel-headers < %{kverstr}
-Obsoletes: glibc-kernheaders < 3.0-46
-
-%description headers
-Kernel-headers includes the C header files that specify the interface
-between the Linux kernel and userspace libraries and programs.  The
-header files define structures and constants that are needed for
-building most standard programs and are also needed for rebuilding the
-glibc package.
-
-%package devel
-Summary: Development package for building kernel modules to match the %{?flavor:%{flavor}} kernel
-Group: System Environment/Kernel
-AutoReqProv: no
-Requires: findutils
-Requires: perl-interpreter
-Requires: openssl-devel
-Requires: flex
-Requires: make
-Requires: bison
-Requires: elfutils-libelf-devel
-Requires: gcc
-%if %{llvm_kbuild}
-Requires: clang
-Requires: llvm
-Requires: lld
-%endif
-Enhances: akmods
-Enhances: dkms
-Provides: installonlypkg(kernel)
-Provides: kernel-devel = %{rpmver}
-Provides: kernel-devel-uname-r = %{kverstr}
-Provides: kernel-devel-%{_arch} = %{rpmver}
-Provides: kernel-devel%{_isa} = %{rpmver}
-Provides: kernel-devel-%{rpmver} = %{kverstr}
-Provides: %{name}-devel-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver}-devel = %{rpmver}
-%description devel
-This package provides kernel headers and makefiles sufficient to build modules
-against the %{?flavor:%{flavor}} kernel package.
-
-%package devel-matched
-Summary: Meta package to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel
-Requires: %{name}-devel = %{rpmver},
-Requires: %{name}-core = %{rpmver}
-Provides: kernel-devel-matched = %{rpmver}
-Provides: kernel-devel-matched%{_isa} = %{rpmver}
-
-%description devel-matched
-This meta package is used to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel.
+    The meta package for %{name}.
 
 %prep
-%setup -q -n linux-%{_tarkver}
+    %setup -q %{?SOURCE10:-b 10} -n linux-%{_tarkver}
+    %autopatch -p1 -v -M 9
 
-tar -xzf %{SOURCE2} -C %{_builddir}
+    cp %{SOURCE1} .config
 
-# Apply CachyOS patch
-patch -p1 -i %{PATCH0}
+    # Default configs to always enable
+    # Enable CACHY sauce and the scheduler
+    # used in the default linux-cachyos kernel
+    scripts/config -e CACHY -e SCHED_BORE
 
-# Apply EEVDF and BORE patches
-patch -p1 -i %{PATCH1}
+    # Use SElinux by default
+    # https://github.com/sirlucjan/copr-linux-cachyos/pull/1
+    scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
-# Replace OpenSSL Engine API with Provider API
-patch -p1 -i %{PATCH2}
+    # Do not change the system's hostname
+    scripts/config -u DEFAULT_HOSTNAME
 
-### Apply patches for nvidia-open
-# Set modeset and fbdev to default enabled
-patch -p1 -i %{PATCH3} -d %{_builddir}/%{_nv_open_pkg}/kernel-open
-# Silence Assert warnings
-patch -p1 -i %{PATCH4} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix for Zen5 error print in dmesg
-patch -p1 -i %{PATCH5} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix HDMI Names
-patch -p1 -i %{PATCH6} -d %{_builddir}/%{_nv_open_pkg}/
+    case %{_hz_tick} in
+        100|250|300|500|600|750|1000)
+            scripts/config -e HZ_%{_hz_tick} --set-val HZ %{_hz_tick};;
+        *)
+            echo "Invalid tickrate value, using default 1000"
+            scripts/config -e HZ_1000 --set-val HZ 1000;;
+    esac
 
-# Fetch the config and move it to the proper directory
-cp %{SOURCE1} .config
+    %if %{_x86_64_lvl} < 5 && %{_x86_64_lvl} > 0
+        scripts/config --set-val X86_64_VERSION %{_x86_64_lvl}
+    %else
+        echo "Invalid x86_64 ISA Level. Using x86_64_v3"
+        scripts/config --set-val X86_64_VERSION 3
+    %endif
 
-# Remove CachyOS's localversion
-find . -name "localversion*" -delete
-scripts/config -u LOCALVERSION
+    %if %{_build_lto}
+        scripts/config -e LTO_CLANG_THIN
+    %endif
 
-# Enable CachyOS tweaks
-scripts/config -e CACHY
+    %if %{_build_minimal}
+        %make_build LSMOD=%{SOURCE2} localmodconfig
+    %else
+        %make_build olddefconfig
+    %endif
 
-# Enable BORE Scheduler
-scripts/config -e SCHED_BORE
+    diff -u %{SOURCE1} .config || :
 
-# Setting tick rate
-scripts/config -d HZ_300
-scripts/config -e HZ_1000
-scripts/config --set-val HZ 1000
-
-# Disable DEBUG
-scripts/config -d DEBUG_INFO
-scripts/config -d DEBUG_INFO_BTF
-scripts/config -d DEBUG_INFO_DWARF4
-scripts/config -d DEBUG_INFO_DWARF5
-scripts/config -d PAHOLE_HAS_SPLIT_BTF
-scripts/config -d DEBUG_INFO_BTF_MODULES
-scripts/config -d SLUB_DEBUG
-scripts/config -d PM_DEBUG
-scripts/config -d PM_ADVANCED_DEBUG
-scripts/config -d PM_SLEEP_DEBUG
-scripts/config -d ACPI_DEBUG
-scripts/config -d SCHED_DEBUG
-scripts/config -d LATENCYTOP
-scripts/config -d DEBUG_PREEMPT
-
-# Enable x86_64_v2
-# Just to be sure, check:
-# /lib/ld-linux-x86-64.so.2 --help | grep supported
-# and make sure if your processor supports it:
-# x86-64-v2 (supported, searched)
-scripts/config --set-val X86_64_VERSION 2
-
-# Set O3
-scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE
-scripts/config -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
-
-# Enable full ticks
-scripts/config -d HZ_PERIODIC
-scripts/config -d NO_HZ_IDLE
-scripts/config -d CONTEXT_TRACKING_FORCE
-scripts/config -e NO_HZ_FULL_NODEF
-scripts/config -e NO_HZ_FULL
-scripts/config -e NO_HZ
-scripts/config -e NO_HZ_COMMON
-scripts/config -e CONTEXT_TRACKING
-
-# Enable full preempt
-scripts/config -e PREEMPT_BUILD
-scripts/config -d PREEMPT_NONE
-scripts/config -d PREEMPT_VOLUNTARY
-scripts/config -e PREEMPT
-scripts/config -e PREEMPT_COUNT
-scripts/config -e PREEMPTION
-scripts/config -e PREEMPT_DYNAMIC
-
-# Enable thin lto
-%if %{llvm_kbuild}
-scripts/config -e LTO
-scripts/config -e LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG_THIN
-scripts/config -d LTO_NONE
-scripts/config -e HAS_LTO_CLANG
-scripts/config -d LTO_CLANG_FULL
-scripts/config -e LTO_CLANG_THIN
-scripts/config -e HAVE_GCC_PLUGINS
-%endif
-
-# Unset hostname
-scripts/config -u DEFAULT_HOSTNAME
-
-# Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
-
-# Set kernel version string as build salt
-scripts/config --set-str BUILD_SALT "%{kverstr}"
-
-# Finalize the patched config
-#make %{?_smp_mflags} EXTRAVERSION=-%{krelstr} oldconfig
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr} olddefconfig
-
-# Save configuration for later reuse
-cat .config > config-linux-bore
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}/kernel-open
+        %patch -P 10 -p1
+        cd ..
+        %autopatch -p1 -v -m 11 -M 19
+    %endif
 
 %build
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr}
-%if %{llvm_kbuild}
-clang ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%else
-gcc ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%endif
+    %make_build EXTRAVERSION=-%{release}.%{_arch} all
+    %make_build -C tools/bpf/bpftool vmlinux.h feature-clang-bpf-co-re=1
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-CFLAGS= CXXFLAGS= LDFLAGS= make %{?llvm_build_env_vars} KERNEL_UNAME=%{kverstr} IGNORE_PREEMPT_RT_PRESENCE=1 IGNORE_CC_MISMATCH=yes SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver} %{?_smp_mflags} modules
-%endif
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        CFLAGS= CXXFLAGS= LDFLAGS= %make_build %{_module_args} IGNORE_CC_MISMATCH=yes modules
+    %endif
 
 %install
+    echo "Installing the kernel image..."
+    install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
+    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
 
-ImageName=$(make image_name | tail -n 1)
+    echo "Installing kernel modules..."
+    ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
 
-mkdir -p %{buildroot}/boot
+    echo "Installing files for the development package..."
+    install -Dt %{buildroot}%{_devel_dir} -m644 .config Makefile Module.symvers System.map tools/bpf/bpftool/vmlinux.h
+    cp .config %{buildroot}%{_kernel_dir}/config
+    cp System.map %{buildroot}%{_kernel_dir}/System.map
+    cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts
+    rm -rf %{buildroot}%{_devel_dir}/include
+    cp -a scripts %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts/tracing
+    rm -f %{buildroot}%{_devel_dir}/scripts/spdxcheck.py
 
-cp -v $ImageName %{buildroot}/boot/vmlinuz-%{kverstr}
-chmod 755 %{buildroot}/boot/vmlinuz-%{kverstr}
+    # The cp commands below are needed for parity with Fedora's packaging
+    # Install files that are needed for `make scripts` to succeed
+    cp -a --parents security/selinux/include/classmap.h %{buildroot}%{_devel_dir}
+    cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}%{_devel_dir}
 
-ZSTD_CLEVEL=19 make %{?_smp_mflags} INSTALL_MOD_PATH=%{buildroot} modules_install mod-fw=
-make %{?_smp_mflags} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
+    # Install files that are needed for `make prepare` to succeed -- Generic
+    cp -a --parents tools/include/linux/compiler* %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux/types.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/build/Build.include %{buildroot}%{_devel_dir}
+    cp --parents tools/build/fixdep.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/sync-check.sh %{buildroot}%{_devel_dir}
+    cp -a --parents tools/bpf/resolve_btfids %{buildroot}%{_devel_dir}
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-install -dm755 "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -Dt "%{buildroot}/usr/share/licenses/nvidia-open" -m644 COPYING
-find "%{buildroot}" -name '*.ko' -exec zstd --rm -19 {} +
-%endif
+    cp --parents security/selinux/include/policycap_names.h %{buildroot}%{_devel_dir}
+    cp --parents security/selinux/include/policycap.h %{buildroot}%{_devel_dir}
 
-# prepare -devel files
-### all of the things here are derived from the Fedora kernel.spec
-### see
-##### https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec
-cd %{_builddir}/linux-%{_tarkver}
-rm -f %{buildroot}/lib/modules/%{kverstr}/build
-rm -f %{buildroot}/lib/modules/%{kverstr}/source
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build
-(cd %{buildroot}/lib/modules/%{kverstr} ; ln -s build source)
-# dirs for additional modules per module-init-tools, kbuild/modules.txt
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/updates
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/weak-updates
-# CONFIG_KERNEL_HEADER_TEST generates some extra files in the process of
-# testing so just delete
-find . -name *.h.s -delete
-# first copy everything
-cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}/lib/modules/%{kverstr}/build
-if [ ! -e Module.symvers ]; then
-touch Module.symvers
-fi
-cp Module.symvers %{buildroot}/lib/modules/%{kverstr}/build
-cp System.map %{buildroot}/lib/modules/%{kverstr}/build
-if [ -s Module.markers ]; then
-cp Module.markers %{buildroot}/lib/modules/%{kverstr}/build
-fi
+    cp -a --parents tools/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/vdso %{buildroot}%{_devel_dir}
+    cp --parents tools/scripts/utilities.mak %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/subcmd %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/*.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/*.[ch] %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/Build %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/include/objtool/*.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/bpf %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/bpf/Build %{buildroot}%{_devel_dir}
 
-# create the kABI metadata for use in packaging
-# NOTENOTE: the name symvers is used by the rpm backend
-# NOTENOTE: to discover and run the /usr/lib/rpm/fileattrs/kabi.attr
-# NOTENOTE: script which dynamically adds exported kernel symbol
-# NOTENOTE: checksums to the rpm metadata provides list.
-# NOTENOTE: if you change the symvers name, update the backend too
-echo "**** GENERATING kernel ABI metadata ****"
-gzip -c9 < Module.symvers > %{buildroot}/boot/symvers-%{kverstr}.gz
-cp %{buildroot}/boot/symvers-%{kverstr}.gz %{buildroot}/lib/modules/%{kverstr}/symvers.gz
+    # Misc headers
+    cp -a --parents arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a include %{buildroot}%{_devel_dir}/include
+    cp -a sound/soc/sof/sof-audio.h %{buildroot}%{_devel_dir}/sound/soc/sof
+    cp -a tools/objtool/objtool %{buildroot}%{_devel_dir}/tools/objtool/
+    cp -a tools/objtool/fixdep %{buildroot}%{_devel_dir}/tools/objtool/
 
-# then drop all but the needed Makefiles/Kconfig files
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/include
-cp .config %{buildroot}/lib/modules/%{kverstr}/build
-cp -a scripts %{buildroot}/lib/modules/%{kverstr}/build
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts/tracing
-rm -f %{buildroot}/lib/modules/%{kverstr}/build/scripts/spdxcheck.py
+    # Install files that are needed for `make prepare` to succeed -- for x86_64
+    cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/stack.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/ctype.h %{buildroot}%{_devel_dir}
 
-%ifarch s390x
-# CONFIG_EXPOLINE_EXTERN=y produces arch/s390/lib/expoline/expoline.o
-# which is needed during external module build.
-if [ -f arch/s390/lib/expoline/expoline.o ]; then
-cp -a --parents arch/s390/lib/expoline/expoline.o %{buildroot}/lib/modules/%{kverstr}/build
-fi
-%endif
+    cp -a --parents scripts/syscalltbl.sh %{buildroot}%{_devel_dir}
+    cp -a --parents scripts/syscallhdr.sh %{buildroot}%{_devel_dir}
 
-# Files for 'make scripts' to succeed with kernel-devel.
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/security/selinux/include
-cp -a --parents security/selinux/include/classmap.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}/lib/modules/%{kverstr}/build
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/tools/include/tools
-cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
+    cp -a --parents tools/arch/x86/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/lib %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/lib/ %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/ %{buildroot}%{_devel_dir}
 
-# Files for 'make prepare' to succeed with kernel-devel.
-cp -a --parents tools/include/linux/compiler* %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux/types.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/build/Build.include %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/fixdep.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/sync-check.sh %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/bpf/resolve_btfids %{buildroot}/lib/modules/%{kverstr}/build
+    # Final cleanups ala Fedora
+    echo "Cleaning up development files..."
+    find %{buildroot}%{_devel_dir}/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    find %{buildroot}%{_devel_dir}/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    touch -r %{buildroot}%{_devel_dir}/Makefile \
+        %{buildroot}%{_devel_dir}/include/generated/uapi/linux/version.h \
+        %{buildroot}%{_devel_dir}/include/config/auto.conf
 
-cp --parents security/selinux/include/policycap_names.h %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents security/selinux/include/policycap.h %{buildroot}/lib/modules/%{kverstr}/build
+    # These links will be owned by the modules package, creating a broken
+    # link unless the -devel package is installed. why??
+    rm -rf %{buildroot}%{_kernel_dir}/build
+    ln -s %{_devel_dir} %{buildroot}%{_kernel_dir}/build
+    ln -s %{_kernel_dir}/build %{buildroot}%{_kernel_dir}/source
 
-cp -a --parents tools/include/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/vdso %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/scripts/utilities.mak %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/subcmd %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/*.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/*.[ch] %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/include/objtool/*.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/bpf %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/bpf/Build %{buildroot}/lib/modules/%{kverstr}/build
+    # Create stub initramfs to inflate disk space requirements.
+    # This should hopefully prevent some initramfs failures due to
+    # insufficient space in /boot (#bz #530778)
+    # 90 seems to be a safe value nowadays. It is slightly inflated than the
+    # measured average to also account for installed vmlinuz in /boot
+    echo "Creating stub initramfs..."
+    install -dm755 %{buildroot}/boot
+    dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{_kver}.img bs=1M count=90
 
-if [ -f tools/objtool/objtool ]; then
-  cp -a tools/objtool/objtool %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -f tools/objtool/fixdep ]; then
-  cp -a tools/objtool/fixdep %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -d arch/%{karch}/scripts ]; then
-  cp -a arch/%{karch}/scripts %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch} || :
-fi
-if [ -f arch/%{karch}/*lds ]; then
-  cp -a arch/%{karch}/*lds %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch}/ || :
-fi
-if [ -f arch/%{asmarch}/kernel/module.lds ]; then
-  cp -a --parents arch/%{asmarch}/kernel/module.lds %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-find %{buildroot}/lib/modules/%{kverstr}/build/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-%ifarch ppc64le
-cp -a --parents arch/powerpc/lib/crtsavres.[So] %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-if [ -d arch/%{asmarch}/include ]; then
-  cp -a --parents arch/%{asmarch}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-%ifarch aarch64
-# arch/arm64/include/asm/xen references arch/arm
-cp -a --parents arch/arm/include/asm/xen %{buildroot}/lib/modules/%{kverstr}/build/
-# arch/arm64/include/asm/opcodes.h references arch/arm
-cp -a --parents arch/arm/include/asm/opcodes.h %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-# include the machine specific headers for ARM variants, if available.
-%ifarch %{arm}
-if [ -d arch/%{asmarch}/mach-${Variant}/include ]; then
-  cp -a --parents arch/%{asmarch}/mach-${Variant}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-# include a few files for 'make prepare'
-cp -a --parents arch/arm/tools/gen-mach-types %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/arm/tools/mach-types %{buildroot}/lib/modules/%{kverstr}/build/
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        echo "Installing NVIDIA open kernel modules..."
+        install -Dt %{buildroot}%{_kernel_dir}/nvidia -m644 kernel-open/*.ko
+        find %{buildroot}%{_kernel_dir}/nvidia -name '*.ko' -exec zstd --rm -19 {} +
+        install -Dt %{buildroot}/%{_defaultlicensedir}/%{name}-nvidia-open -m644 COPYING
+    %endif
 
-%endif
-cp -a include %{buildroot}/lib/modules/%{kverstr}/build/include
+%package core
+Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
+AutoReq:        no
+Conflicts:      xfsprogs < 4.3.0-1
+Conflicts:      xorg-x11-drv-vmmouse < 13.0.99
+Provides:       kernel = %{_rpmver}
+Provides:       kernel-core-uname-r = %{_kver}
+Provides:       kernel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires(pre):  /usr/bin/kernel-install
+Requires(pre):  coreutils
+Requires(pre):  dracut >= 027
+Requires(pre):  systemd >= 203-2
+Requires(pre):  ((linux-firmware >= 20150904-56.git6ebf5d57) if linux-firmware)
+Requires(preun):systemd >= 200
+Recommends:     linux-firmware
 
-%ifarch i686 x86_64
-# files for 'make prepare' to succeed with kernel-devel
-cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/stack.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/ctype.h %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents scripts/syscalltbl.sh %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents scripts/syscallhdr.sh %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents tools/arch/x86/include/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/lib %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/lib/ %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/ %{buildroot}/lib/modules/%{kverstr}/build
-
-%endif
-# Clean up intermediate tools files
-find %{buildroot}/lib/modules/%{kverstr}/build/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-
-# Make sure the Makefile, version.h, and auto.conf have a matching
-# timestamp so that external modules can be built
-touch -r %{buildroot}/lib/modules/%{kverstr}/build/Makefile \
-%{buildroot}/lib/modules/%{kverstr}/build/include/generated/uapi/linux/version.h \
-%{buildroot}/lib/modules/%{kverstr}/build/include/config/auto.conf
-
-find %{buildroot}/lib/modules/%{kverstr} -name "*.ko" -type f >modnames
-
-# mark modules executable so that strip-to-file can strip them
-xargs --no-run-if-empty chmod u+x < modnames
-
-# Generate a list of modules for block and networking.
-
-grep -F /drivers/ modnames | xargs --no-run-if-empty nm -upA |
-sed -n 's,^.*/\([^/]*\.ko\):  *U \(.*\)$,\1 \2,p' > drivers.undef
-
-collect_modules_list()
-{
-  sed -r -n -e "s/^([^ ]+) \\.?($2)\$/\\1/p" drivers.undef |
-LC_ALL=C sort -u > %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  if [ ! -z "$3" ]; then
-sed -r -e "/^($3)\$/d" -i %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  fi
-}
-
-collect_modules_list networking \
-  'register_netdev|ieee80211_register_hw|usbnet_probe|phy_driver_register|rt(l_|2x00)(pci|usb)_probe|register_netdevice'
-collect_modules_list block \
-  'ata_scsi_ioctl|scsi_add_host|scsi_add_host_with_dma|blk_alloc_queue|blk_init_queue|register_mtd_blktrans|scsi_esp_register|scsi_register_device_handler|blk_queue_physical_block_size' 'pktcdvd.ko|dm-mod.ko'
-collect_modules_list drm \
-  'drm_open|drm_init'
-collect_modules_list modesetting \
-  'drm_crtc_init'
-
-# detect missing or incorrect license tags
-( find %{buildroot}/lib/modules/%{kverstr} -name '*.ko' | xargs /sbin/modinfo -l | \
-grep -E -v 'GPL( v2)?$|Dual BSD/GPL$|Dual MPL/GPL$|GPL and additional rights$' ) && exit 1
-
-remove_depmod_files()
-{
-# remove files that will be auto generated by depmod at rpm -i time
-pushd %{buildroot}/lib/modules/%{kverstr}/
-rm -f modules.{alias,alias.bin,builtin.alias.bin,builtin.bin} \
-  modules.{dep,dep.bin,devname,softdep,symbols,symbols.bin}
-popd
-}
-
-remove_depmod_files
-
-mkdir -p %{buildroot}%{_prefix}/src/kernels
-mv %{buildroot}/lib/modules/%{kverstr}/build %{buildroot}%{_prefix}/src/kernels/%{kverstr}
-
-# This is going to create a broken link during the build, but we don't use
-# it after this point.  We need the link to actually point to something
-# when kernel-devel is installed, and a relative link doesn't work across
-# the F17 UsrMove feature.
-ln -sf %{_prefix}/src/kernels/%{kverstr} %{buildroot}/lib/modules/%{kverstr}/build
-
-find %{buildroot}%{_prefix}/src/kernels -name ".*.cmd" -delete
-#
-
-cp -v System.map %{buildroot}/boot/System.map-%{kverstr}
-cp -v System.map %{buildroot}/lib/modules/%{kverstr}/System.map
-cp -v .config %{buildroot}/boot/config-%{kverstr}
-cp -v .config %{buildroot}/lib/modules/%{kverstr}/config
-
-(cd "%{buildroot}/boot/" && sha512hmac "vmlinuz-%{kverstr}" > ".vmlinuz-%{kverstr}.hmac")
-
-cp -v  %{buildroot}/boot/vmlinuz-%{kverstr} %{buildroot}/lib/modules/%{kverstr}/vmlinuz
-(cd "%{buildroot}/lib/modules/%{kverstr}" && sha512hmac vmlinuz > .vmlinuz.hmac)
-
-# create dummy initramfs image to inflate the disk space requirement for the initramfs. 48M seems to be the right size nowadays with more and more hardware requiring initramfs-located firmware to work properly (for reference, Fedora has it set to 20M)
-dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{kverstr}.img bs=1M count=48
-
-%clean
-rm -rf %{buildroot}
+%description core
+    The kernel package contains the Linux kernel (vmlinuz), the core of any
+    Linux operating system.  The kernel handles the basic functions
+    of the operating system: memory allocation, process allocation, device
+    input and output, etc.
 
 %post core
-if [ `uname -i` == "x86_64" -o `uname -i` == "i386" ] &&
-   [ -f /etc/sysconfig/kernel ]; then
-  /bin/sed -r -i -e 's/^DEFAULTKERNEL=kernel-smp$/DEFAULTKERNEL=kernel/' /etc/sysconfig/kernel || exit $?
-fi
-if [ -x /bin/kernel-install ] && [ -d /boot ]; then
-/bin/kernel-install add %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-fi
+    mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+    touch %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
 
 %posttrans core
-if [ ! -z $(rpm -qa | grep grubby) ]; then
-  grubby --set-default="/boot/vmlinuz-%{kverstr}"
-fi
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
+        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
+            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+            if command -v restorecon &>/dev/null; then
+                restorecon "/boot/symvers-%{_kver}.zst"
+            fi
+        fi
+    fi
 
 %preun core
-/bin/kernel-install remove %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-if [ -x /usr/sbin/weak-modules ]
-then
-/usr/sbin/weak-modules --remove-kernel %{kverstr} || exit $?
-fi
-
-%post devel
-if [ -f /etc/sysconfig/kernel ]
-then
-. /etc/sysconfig/kernel || exit $?
-fi
-if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]
-then
-(cd /usr/src/kernels/%{kverstr} &&
- /usr/bin/find . -type f | while read f; do
-   hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f 2>&1 >/dev/null
- done)
-fi
-
-%post modules
-/sbin/depmod -a %{kverstr}
-
-%if %{_nv_build}
-%posttrans nvidia-open
-/sbin/depmod -a %{kverstr}
-%endif
+    /bin/kernel-install remove %{_kver} || exit $?
+    if [ -x /usr/sbin/weak-modules ]; then
+        /usr/sbin/weak-modules --remove-kernel %{_kver} || exit $?
+    fi
 
 %files core
-%ghost %attr(0600, root, root) /boot/vmlinuz-%{kverstr}
-%ghost %attr(0600, root, root) /boot/System.map-%{kverstr}
-%ghost %attr(0600, root, root) /boot/initramfs-%{kverstr}.img
-%ghost %attr(0600, root, root) /boot/symvers-%{kverstr}.gz
-%ghost %attr(0644, root, root) /boot/config-%{kverstr}
-/boot/.vmlinuz-%{kverstr}.hmac
-%dir /lib/modules/%{kverstr}/
-/lib/modules/%{kverstr}/.vmlinuz.hmac
-/lib/modules/%{kverstr}/config
-/lib/modules/%{kverstr}/vmlinuz
-/lib/modules/%{kverstr}/System.map
-/lib/modules/%{kverstr}/symvers.gz
+    %dir %{_kernel_dir}
+    %license COPYING
+    %ghost /boot/initramfs-%{_kver}.img
+    %{_kernel_dir}/vmlinuz
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
+    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/config
+    %{_kernel_dir}/System.map
+
+%package modules
+Summary:        Kernel modules package for %{name}
+Provides:       kernel-modules = %{_rpmver}
+Provides:       kernel-modules-core = %{_rpmver}
+Provides:       kernel-modules-uname-r = %{_kver}
+Provides:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+
+%description modules
+    This package provides kernel modules for the %{name}-core kernel package.
+
+%post modules
+    /sbin/depmod -a %{_kver}
+    if [ ! -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver} ]; then
+        mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+        touch %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    fi
+
+%posttrans modules
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        if [ -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver} ]; then
+            echo "Running: dracut -f --kver %{_kver}"
+            dracut -f --kver "%{_kver}" || exit $?
+        fi
+    fi
+
+%postun modules
+    /sbin/depmod -a %{_kver}
 
 %files modules
-/lib/modules/%{kverstr}/
-%exclude /lib/modules/%{kverstr}/.vmlinuz.hmac
-%exclude /lib/modules/%{kverstr}/config
-%exclude /lib/modules/%{kverstr}/vmlinuz
-%exclude /lib/modules/%{kverstr}/System.map
-%exclude /lib/modules/%{kverstr}/symvers.gz
-%exclude /lib/modules/%{kverstr}/build
-%exclude /lib/modules/%{kverstr}/source
-%if %{_nv_build}
-%exclude /lib/modules/%{kverstr}/nvidia
+    %{_kernel_dir}/modules.order
+    %{_kernel_dir}/build
+    %{_kernel_dir}/source
+    %{_kernel_dir}/kernel
 
-%files nvidia-open
-/lib/modules/%{kverstr}/nvidia
-/usr/share/licenses/nvidia-open/COPYING
+%package devel
+Summary:        Development package for building kernel modules to match %{name}
+Provides:       kernel-devel = %{_rpmver}
+Provides:       kernel-devel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+AutoReqProv:    no
+Requires(pre):  findutils
+Requires:       findutils
+Requires:       perl-interpreter
+Requires:       openssl-devel
+Requires:       elfutils-libelf-devel
+Requires:       bison
+Requires:       flex
+Requires:       make
+
+%if %{_build_lto}
+Requires:       clang
+Requires:       lld
+Requires:       llvm
+%else
+Requires:       gcc
 %endif
 
-%files headers
-%defattr (-, root, root)
-/usr/include/*
+%description devel
+    This package provides kernel headers and makefiles sufficient to build modules against %{name}.
+
+%post devel
+    if [ -f /etc/sysconfig/kernel ]; then
+        . /etc/sysconfig/kernel || exit $?
+    fi
+    if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]; then
+        (cd /usr/src/kernels/%{_kver} &&
+        /usr/bin/find . -type f | while read f; do
+            hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f > /dev/null
+        done;
+        )
+    fi
 
 %files devel
-%defattr (-, root, root)
-/usr/src/kernels/%{kverstr}
-/lib/modules/%{kverstr}/build
-/lib/modules/%{kverstr}/source
+    %{_devel_dir}
+
+%package devel-matched
+Summary:        Meta package to install matching core and devel packages for %{name}
+Provides:       kernel-devel-matched = %{_rpmver}
+Requires:       %{name}-core = %{_rpmver}
+Requires:       %{name}-devel = %{_rpmver}
+
+%description devel-matched
+    This meta package is used to install matching core and devel packages for %{name}.
 
 %files devel-matched
 
+%if %{_build_nv}
+%package nvidia-open
+Summary:        nvidia-open %{_nv_ver} kernel modules for %{name}
+Provides:       nvidia-kmod >= %{_nv_ver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+Conflicts:      akmod-nvidia
+Recommends:     xorg-x11-drv-nvidia >= %{_nv_ver}
+
+%description nvidia-open
+    This package provides nvidia-open %{_nv_ver} kernel modules for %{name}.
+
+%post nvidia-open
+    /sbin/depmod -a %{_kver}
+
+%files nvidia-open
+    %license %{_defaultlicensedir}/%{name}-nvidia-open/COPYING
+    %{_kernel_dir}/nvidia
+%endif
+
 %files
+
+

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos-rt%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyrt1%{?_lto_args:.lto}%{?dist}
+Release:        cachyrt2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -376,8 +376,6 @@ Recommends:     linux-firmware
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
-    %{_kernel_dir}/modules.builtin
-    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/symvers.zst
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
@@ -410,10 +408,9 @@ Requires:       kernel-uname-r = %{_kver}
         fi
     fi
 
-%postun modules
-    /sbin/depmod -a %{_kver}
-
 %files modules
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/modules.order
     %{_kernel_dir}/build
     %{_kernel_dir}/source

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -1,748 +1,491 @@
-### A port of linux-cachyos (https://github.com/CachyOS/linux-cachyos/tree/master/linux-cachyos) for the Fedora operating system.
-# https://github.com/CachyOS/linux-cachyos
-### The authors of linux-cachyos patchset:
-# Peter Jung ptr1337 <admin@ptr1337.dev>
-# Piotr Gorski sirlucjan <piotrgorski@cachyos.org>
-### The author of BORE-EEVDF Scheduler:
-# Masahito Suzuki <firelzrd@gmail.com>
-### The port maintainer for Fedora:
-# bieszczaders <zbyszek@linux.pl>
-# https://copr.fedorainfracloud.org/coprs/bieszczaders/
+# Maintainer: Eric Naim <dnaim@cachyos.org>
 
-%define _build_id_links none
+# Fedora bits
+%define __spec_install_post %{__os_install_post}
+%define _default_patch_fuzz 2
 %define _disable_source_fetch 0
-
-# See https://fedoraproject.org/wiki/Changes/SetBuildFlagsBuildCheck to why this has to be done
-%if 0%{?fedora} >= 37
-%undefine _auto_set_build_flags
-%endif
-
-%ifarch x86_64
-%define karch x86
-%define asmarch x86
-%endif
-
-# define git branch to make testing easier without merging to master branch
-%define _git_branch master
-
-# whether to build kernel with llvm compiler(clang)
-%define llvm_kbuild 0
-%if %{llvm_kbuild}
-%define llvm_build_env_vars CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
-%define ltoflavor 1
-%endif
-
-%define flavor cachyos-rt
-Name: kernel%{?flavor:-%{flavor}}%{?ltoflavor:-lto}
-Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
-
-%define _basekver 6.12
-%define _stablekver 9
-%if %{_stablekver} == 0
-%define _tarkver %{_basekver}
-%else
-%define _tarkver %{_basekver}.%{_stablekver}
-%endif
-
-Version: %{_basekver}.%{_stablekver}
-
-%define customver 1
-%define flaver cbrt%{customver}
-
-Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
-
-# Define rawhide fedora version
-%define _rawhidever 42
-
-# Build nvidia-open alongside the kernel
-%define _nv_build 1
-%if 0%{?fedora} >= 41
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%else
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%endif
-%define _nv_open_pkg open-gpu-kernel-modules-%{_nv_ver}
-
-%define rpmver %{version}-%{release}
-%define krelstr %{release}.%{_arch}
-%define kverstr %{version}-%{krelstr}
-
-License: GPLv2 and Redistributable, no modifications permitted
-Group: System Environment/Kernel
-Vendor: The Linux Community and CachyOS maintainer(s)
-URL: https://cachyos.org
-Source0: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
-Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-rt-bore/config
-Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
-# Stable patches
-Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
-Patch2: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/0001-rt.patch
-
-Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled.patch
-Patch4: %{_nvidia_patchurl}/0004-silence-event-assert-until-570.patch
-Patch5: %{_nvidia_patchurl}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
-Patch6: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
-
-# Dev patches
-#Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all-dev.patch
-#Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched-dev/0001-bore-cachy.patch
-%define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
-BuildRequires: python3-devel
-BuildRequires: make
-BuildRequires: perl-generators
-BuildRequires: perl-interpreter
-BuildRequires: openssl-devel
-BuildRequires: bison
-BuildRequires: flex
-BuildRequires: findutils
-BuildRequires: git-core
-BuildRequires: perl-devel
-BuildRequires: openssl
-BuildRequires: elfutils-devel
-BuildRequires: gawk
-BuildRequires: binutils
-BuildRequires: m4
-BuildRequires: tar
-BuildRequires: hostname
-BuildRequires: bzip2
-BuildRequires: bash
-BuildRequires: gzip
-BuildRequires: xz
-BuildRequires: bc
-BuildRequires: diffutils
-BuildRequires: redhat-rpm-config
-BuildRequires: net-tools
-BuildRequires: elfutils
-BuildRequires: patch
-BuildRequires: rpm-build
-BuildRequires: dwarves
-BuildRequires: kmod
-BuildRequires: libkcapi-hmaccalc
-BuildRequires: perl-Carp
-BuildRequires: rsync
-BuildRequires: grubby
-BuildRequires: wget
-BuildRequires: gcc
-BuildRequires: gcc-c++
-%if %{llvm_kbuild}
-BuildRequires: llvm
-BuildRequires: clang
-BuildRequires: lld
+%define make_build make %{?_lto_args} %{?_smp_mflags}
+%undefine __brp_mangle_shebangs
+%undefine _auto_set_build_flags
+%undefine _include_frame_pointers
+
+# Linux Kernel Versions
+%define _basekver 6.12
+%define _stablekver 10
+%define _rpmver %{version}-%{release}
+%define _kver %{_rpmver}.%{_arch}
+
+%if %{_stablekver} == 0
+    %define _tarkver %{_basekver}
+%else
+    %define _tarkver %{version}
 %endif
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-rt >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-rt >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-rt <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-rt <= 6.5.10-cb1
+
+# Build a minimal a kernel via modprobed.db
+# file to reduce build times
+%define _build_minimal 0
+
+# Builds the kernel with clang and enables
+# ThinLTO
+%define _build_lto 0
+
+# Builds nvidia-open kernel modules with
+# the kernel
+%define _build_nv 1
+%define _nv_ver 565.77
+%define _nv_pkg open-gpu-kernel-modules-%{_nv_ver}
+
+# Define the tickrate used by the kernel
+# Valid values: 100, 250, 300, 500, 600, 750 and 1000
+# An invalid value will not fail and continue to use
+# 1000Hz tickrate
+%define _hz_tick 1000
+
+# Defines the x86_64 ISA level used
+# to compile the kernel
+# Valid values are 1-4
+# An invalid value will continue and use
+# x86_64_v3
+%define _x86_64_lvl 3
+
+# Define variables for directory paths
+# to be used during packaging
+%define _kernel_dir /lib/modules/%{_kver}
+%define _devel_dir %{_usrsrc}/kernels/%{_kver}
+
+%define _patch_src https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}
+
+%if %{_build_lto}
+    # Define build environment variables to build the kernel with clang
+    %define _lto_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
+%endif
+
+%define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver}
+
+Name:           kernel-cachyos-rt%{?_lto_args:-lto}
+Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
+Version:        %{_basekver}.%{_stablekver}
+Release:        cachyrt1%{?_lto_args:.lto}%{?dist}
+License:        GPL-2.0-only
+URL:            https://cachyos.org
+
+Requires:       kernel-core-uname-r = %{_kver}
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+
+BuildRequires:  bc
+BuildRequires:  bison
+BuildRequires:  dwarves
+BuildRequires:  elfutils-devel
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  gettext-devel
+BuildRequires:  kmod
+BuildRequires:  make
+BuildRequires:  openssl
+BuildRequires:  openssl-devel
+BuildRequires:  perl-Carp
+BuildRequires:  perl-devel
+BuildRequires:  perl-generators
+BuildRequires:  perl-interpreter
+BuildRequires:  python3-devel
+BuildRequires:  python3-pyyaml
+BuildRequires:  python-srpm-macros
+
+%if %{_build_lto}
+BuildRequires:  clang
+BuildRequires:  lld
+BuildRequires:  llvm
+%endif
+
+%if %{_build_nv}
+BuildRequires:  gcc-c++
+%endif
+
+# Indexes 0-9 are reserved for the kernel. 10-19 will be reserved for NVIDIA
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
+Source1:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/config
+
+%if %{_build_minimal}
+# The default modprobed.db provided is used for linux-cachyos CI.
+# This should not be used for production and ideally should only be used for compile tests.
+# Note that any modprobed.db file is accepted
+Source2:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/modprobed.db
+%endif
+
+%if %{_build_nv}
+Source10:       https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_pkg}.tar.gz
+%endif
+
+Patch0:         %{_patch_src}/all/0001-cachyos-base-all.patch
+Patch1:         %{_patch_src}/sched/0001-bore-cachy.patch
+Patch2:         %{_patch_src}/misc/0001-rt.patch
+
+%if %{_build_lto}
+Patch2:         %{_patch_src}/misc/dkms-clang.patch
+%endif
+
+%if %{_build_nv}
+Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch
+Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
+Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
+Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+%endif
 
 %description
-The kernel-%{flaver} meta package
-
-%package core
-Summary: Kernel core package
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel)
-Provides: kernel = %{rpmver}
-Provides: kernel-core = %{rpmver}
-Provides: kernel-core-uname-r = %{kverstr}
-Provides: kernel-uname-r = %{kverstr}
-Provides: kernel-%{_arch} = %{rpmver}
-Provides: kernel-core%{_isa} = %{rpmver}
-Provides: kernel-core-%{rpmver} = %{kverstr}
-Provides: %{name}-core-%{rpmver} = %{kverstr}
-Provides:  kernel-drm-nouveau = 16
-# multiver
-Provides: %{name}%{_basekver}-core = %{rpmver}
-Requires: bash
-Requires: coreutils
-Requires: dracut
-Requires: linux-firmware
-Requires: /usr/bin/kernel-install
-Requires: kernel-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-rt-core >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-rt-core >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-rt-core <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-rt-core <= 6.5.10-cb1
-%description core
-The kernel package contains the Linux kernel (vmlinuz), the core of any
-Linux operating system.  The kernel handles the basic functions
-of the operating system: memory allocation, process allocation, device
-input and output, etc.
-
-%package modules
-Summary: Kernel modules to match the core kernel
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel-module)
-Provides: %{name}%{_basekver}-modules = %{rpmver}
-Provides: kernel-modules = %{rpmver}
-Provides: kernel-modules%{_isa} = %{rpmver}
-Provides: kernel-modules-uname-r = %{kverstr}
-Provides: kernel-modules-%{_arch} = %{rpmver}
-Provides: kernel-modules-%{rpmver} = %{kverstr}
-Provides: %{name}-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-rt-modules >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-rt-modules >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-rt-modules <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-rt-modules <= 6.5.10-cb1
-%description modules
-This package provides kernel modules for the core %{?flavor:%{flavor}} kernel package.
-
-%if %{_nv_build}
-%package nvidia-open
-Summary: Prebuilt nvidia-open kernel modules to match the core kernel
-Group: System Environment/Kernel
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: nvidia-kmod >= %{_nv_ver}
-Provides: installonlypkg(kernel-module)
-Conflicts: akmod-nvidia
-Recommends: xorg-x11-drv-nvidia >= %{_nv_ver}
-%description nvidia-open
-This package provides prebuilt nvidia-open kernel modules for the core %{?flavor:%{flavor}} kernel package.
-%endif
-
-%package headers
-Summary: Header files for the Linux kernel for use by glibc
-Group: Development/System
-Provides: kernel-headers = %{kverstr}
-Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers%{_isa} = %{kverstr}
-Obsoletes: kernel-headers < %{kverstr}
-Obsoletes: glibc-kernheaders < 3.0-46
-Obsoletes: kernel-cachyos-bore-eevdf-rt-headers <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-rt-headers <= 6.5.10-cb1
-Provides: kernel-cachyos-bore-eevdf-rt-headers >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-rt-headers >= 6.5.7-cb1
-%description headers
-Kernel-headers includes the C header files that specify the interface
-between the Linux kernel and userspace libraries and programs.  The
-header files define structures and constants that are needed for
-building most standard programs and are also needed for rebuilding the
-glibc package.
-
-%package devel
-Summary: Development package for building kernel modules to match the %{?flavor:%{flavor}} kernel
-Group: System Environment/Kernel
-AutoReqProv: no
-Requires: findutils
-Requires: perl-interpreter
-Requires: openssl-devel
-Requires: flex
-Requires: make
-Requires: bison
-Requires: elfutils-libelf-devel
-Requires: gcc
-%if %{llvm_kbuild}
-Requires: clang
-Requires: llvm
-Requires: lld
-%endif
-Enhances: akmods
-Enhances: dkms
-Provides: installonlypkg(kernel)
-Provides: kernel-devel = %{rpmver}
-Provides: kernel-devel-uname-r = %{kverstr}
-Provides: kernel-devel-%{_arch} = %{rpmver}
-Provides: kernel-devel%{_isa} = %{rpmver}
-Provides: kernel-devel-%{rpmver} = %{kverstr}
-Provides: %{name}-devel-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver}-devel = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-rt-devel >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-rt-devel >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-rt-devel <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-rt-devel <= 6.5.10-cb1
-%description devel
-This package provides kernel headers and makefiles sufficient to build modules
-against the %{?flavor:%{flavor}} kernel package.
-
-%package devel-matched
-Summary: Meta package to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel
-Requires: %{name}-devel = %{rpmver},
-Requires: %{name}-core = %{rpmver}
-Provides: kernel-devel-matched = %{rpmver}
-Provides: kernel-devel-matched%{_isa} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-rt-devel-matched >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-rt-devel-matched >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-rt-devel-matched <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-rt-devel-matched <= 6.5.10-cb1
-%description devel-matched
-This meta package is used to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel.
+    The meta package for %{name}.
 
 %prep
-%setup -q -n linux-%{_tarkver}
+    %setup -q %{?SOURCE10:-b 10} -n linux-%{_tarkver}
+    %autopatch -p1 -v -M 9
 
-tar -xzf %{SOURCE2} -C %{_builddir}
+    cp %{SOURCE1} .config
 
-# Apply CachyOS patch
-patch -p1 -i %{PATCH0}
+    # Default configs to always enable
+    # Enable CACHY sauce and the scheduler
+    # used in the default linux-cachyos kernel
+    scripts/config -e CACHY -e SCHED_BORE
 
-# Apply EEVDF and BORE patches
-patch -p1 -i %{PATCH1}
+    # Use SElinux by default
+    # https://github.com/sirlucjan/copr-linux-cachyos/pull/1
+    scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
-# Apply RT patch
-patch -p1 -i %{PATCH2}
+    # Do not change the system's hostname
+    scripts/config -u DEFAULT_HOSTNAME
 
-### Apply patches for nvidia-open
-# Set modeset and fbdev to default enabled
-patch -p1 -i %{PATCH3} -d %{_builddir}/%{_nv_open_pkg}/kernel-open
-# Silence Assert warnings
-patch -p1 -i %{PATCH4} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix for Zen5 error print in dmesg
-patch -p1 -i %{PATCH5} -d %{_builddir}/%{_nv_open_pkg}/
-# Patches for Nvidia on kernel 6.12
-patch -p1 -i %{PATCH6} -d %{_builddir}/%{_nv_open_pkg}/
+    # Enable PREEMPT_RT
+    scripts/config -d PREEMPT_DYNAMIC -d PREEMPT
+    scripts/config -e PREEMPT_RT
 
+    case %{_hz_tick} in
+        100|250|300|500|600|750|1000)
+            scripts/config -e HZ_%{_hz_tick} --set-val HZ %{_hz_tick};;
+        *)
+            echo "Invalid tickrate value, using default 1000"
+            scripts/config -e HZ_1000 --set-val HZ 1000;;
+    esac
 
-# Fetch the config and move it to the proper directory
-cp %{SOURCE1} .config
+    %if %{_x86_64_lvl} < 5 && %{_x86_64_lvl} > 0
+        scripts/config --set-val X86_64_VERSION %{_x86_64_lvl}
+    %else
+        echo "Invalid x86_64 ISA Level. Using x86_64_v3"
+        scripts/config --set-val X86_64_VERSION 3
+    %endif
 
-# Remove CachyOS's localversion
-find . -name "localversion*" -delete
-scripts/config -u LOCALVERSION
+    %if %{_build_lto}
+        scripts/config -e LTO_CLANG_THIN
+    %endif
 
-# Enable CachyOS tweaks
-scripts/config -e CACHY
+    %if %{_build_minimal}
+        %make_build LSMOD=%{SOURCE2} localmodconfig
+    %else
+        %make_build olddefconfig
+    %endif
 
-# Enable BORE Scheduler
-scripts/config -e SCHED_BORE
+    diff -u %{SOURCE1} .config || :
 
-# Enable sched-ext
-scripts/config -e SCHED_CLASS_EXT
-scripts/config -e BPF
-scripts/config -e BPF_EVENTS
-scripts/config -e BPF_JIT
-scripts/config -e BPF_SYSCALL
-scripts/config -e DEBUG_INFO
-scripts/config -e DEBUG_INFO_BTF
-scripts/config -e DEBUG_INFO_BTF_MODULES
-scripts/config -e FTRACE
-scripts/config -e PAHOLE_HAS_SPLIT_BTF
-scripts/config -e DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT
-scripts/config -e SCHED_DEBUG
-
-# Setting tick rate
-scripts/config -d HZ_300
-scripts/config -e HZ_1000
-scripts/config --set-val HZ 1000
-
-# Enable x86_64_v3
-# Just to be sure, check:
-# /lib/ld-linux-x86-64.so.2 --help | grep supported
-# and make sure if your processor supports it:
-# x86-64-v3 (supported, searched)
-scripts/config --set-val X86_64_VERSION 3
-
-# Set O3
-scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE
-scripts/config -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
-
-# Enable idle ticks
-scripts/config -d HZ_PERIODIC
-scripts/config -d NO_HZ_FULL
-scripts/config -e NO_HZ_IDLE
-scripts/config -e NO_HZ
-scripts/config -e NO_HZ_COMMON
-
-# Enable RT config
-scripts/config -e PREEMPT_COUNT
-scripts/config -e PREEMPTION
-scripts/config -d PREEMPT_VOLUNTARY
-scripts/config -d PREEMPT
-scripts/config -d PREEMPT_NONE
-scripts/config -e PREEMPT_RT
-scripts/config -d PREEMPT_AUTO
-scripts/config -d PREEMPT_DYNAMIC
-scripts/config -d HAVE_PREEMPT_AUTO
-scripts/config -d PREEMPT_BUILD
-
-# Enable thin lto
-%if %{llvm_kbuild}
-scripts/config -e LTO
-scripts/config -e LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG_THIN
-scripts/config -d LTO_NONE
-scripts/config -e HAS_LTO_CLANG
-scripts/config -d LTO_CLANG_FULL
-scripts/config -e LTO_CLANG_THIN
-scripts/config -e HAVE_GCC_PLUGINS
-%endif
-
-# Unset hostname
-scripts/config -u DEFAULT_HOSTNAME
-
-# Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
-
-# Set kernel version string as build salt
-scripts/config --set-str BUILD_SALT "%{kverstr}"
-
-# Finalize the patched config
-#make %{?_smp_mflags} EXTRAVERSION=-%{krelstr} oldconfig
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr} olddefconfig
-
-# Save configuration for later reuse
-cat .config > config-linux-bore
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}/kernel-open
+        %patch -P 10 -p1
+        cd ..
+        %autopatch -p1 -v -m 11 -M 19
+    %endif
 
 %build
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr}
-%if %{llvm_kbuild}
-clang ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%else
-gcc ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%endif
+    %make_build EXTRAVERSION=-%{release}.%{_arch} all
+    %make_build -C tools/bpf/bpftool vmlinux.h feature-clang-bpf-co-re=1
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-CFLAGS= CXXFLAGS= LDFLAGS= make %{?llvm_build_env_vars} KERNEL_UNAME=%{kverstr} IGNORE_PREEMPT_RT_PRESENCE=1 IGNORE_CC_MISMATCH=yes SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver} %{?_smp_mflags} modules
-%endif
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        CFLAGS= CXXFLAGS= LDFLAGS= %make_build %{_module_args} IGNORE_CC_MISMATCH=yes modules
+    %endif
 
 %install
+    echo "Installing the kernel image..."
+    install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
+    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
 
-ImageName=$(make image_name | tail -n 1)
+    echo "Installing kernel modules..."
+    ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
 
-mkdir -p %{buildroot}/boot
+    echo "Installing files for the development package..."
+    install -Dt %{buildroot}%{_devel_dir} -m644 .config Makefile Module.symvers System.map tools/bpf/bpftool/vmlinux.h
+    cp .config %{buildroot}%{_kernel_dir}/config
+    cp System.map %{buildroot}%{_kernel_dir}/System.map
+    cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts
+    rm -rf %{buildroot}%{_devel_dir}/include
+    cp -a scripts %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts/tracing
+    rm -f %{buildroot}%{_devel_dir}/scripts/spdxcheck.py
 
-cp -v $ImageName %{buildroot}/boot/vmlinuz-%{kverstr}
-chmod 755 %{buildroot}/boot/vmlinuz-%{kverstr}
+    # The cp commands below are needed for parity with Fedora's packaging
+    # Install files that are needed for `make scripts` to succeed
+    cp -a --parents security/selinux/include/classmap.h %{buildroot}%{_devel_dir}
+    cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}%{_devel_dir}
 
-ZSTD_CLEVEL=19 make %{?_smp_mflags} %{?llvm_build_env_vars} INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_STRIP=1 modules_install mod-fw=
-make %{?_smp_mflags} %{?llvm_build_env_vars} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
+    # Install files that are needed for `make prepare` to succeed -- Generic
+    cp -a --parents tools/include/linux/compiler* %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux/types.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/build/Build.include %{buildroot}%{_devel_dir}
+    cp --parents tools/build/fixdep.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/sync-check.sh %{buildroot}%{_devel_dir}
+    cp -a --parents tools/bpf/resolve_btfids %{buildroot}%{_devel_dir}
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-install -dm755 "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -Dt "%{buildroot}/usr/share/licenses/nvidia-open" -m644 COPYING
-find "%{buildroot}" -name '*.ko' -exec zstd --rm -19 {} +
-%endif
+    cp --parents security/selinux/include/policycap_names.h %{buildroot}%{_devel_dir}
+    cp --parents security/selinux/include/policycap.h %{buildroot}%{_devel_dir}
 
-# prepare -devel files
-### all of the things here are derived from the Fedora kernel.spec
-### see
-##### https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec
-cd %{_builddir}/linux-%{_tarkver}
-rm -f %{buildroot}/lib/modules/%{kverstr}/build
-rm -f %{buildroot}/lib/modules/%{kverstr}/source
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build
-(cd %{buildroot}/lib/modules/%{kverstr} ; ln -s build source)
-# dirs for additional modules per module-init-tools, kbuild/modules.txt
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/updates
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/weak-updates
-# CONFIG_KERNEL_HEADER_TEST generates some extra files in the process of
-# testing so just delete
-find . -name *.h.s -delete
-# first copy everything
-cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}/lib/modules/%{kverstr}/build
-if [ ! -e Module.symvers ]; then
-touch Module.symvers
-fi
-cp Module.symvers %{buildroot}/lib/modules/%{kverstr}/build
-cp System.map %{buildroot}/lib/modules/%{kverstr}/build
-if [ -s Module.markers ]; then
-cp Module.markers %{buildroot}/lib/modules/%{kverstr}/build
-fi
+    cp -a --parents tools/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/vdso %{buildroot}%{_devel_dir}
+    cp --parents tools/scripts/utilities.mak %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/subcmd %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/*.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/*.[ch] %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/Build %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/include/objtool/*.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/bpf %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/bpf/Build %{buildroot}%{_devel_dir}
 
-# create the kABI metadata for use in packaging
-# NOTENOTE: the name symvers is used by the rpm backend
-# NOTENOTE: to discover and run the /usr/lib/rpm/fileattrs/kabi.attr
-# NOTENOTE: script which dynamically adds exported kernel symbol
-# NOTENOTE: checksums to the rpm metadata provides list.
-# NOTENOTE: if you change the symvers name, update the backend too
-echo "**** GENERATING kernel ABI metadata ****"
-gzip -c9 < Module.symvers > %{buildroot}/boot/symvers-%{kverstr}.gz
-cp %{buildroot}/boot/symvers-%{kverstr}.gz %{buildroot}/lib/modules/%{kverstr}/symvers.gz
+    # Misc headers
+    cp -a --parents arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a include %{buildroot}%{_devel_dir}/include
+    cp -a sound/soc/sof/sof-audio.h %{buildroot}%{_devel_dir}/sound/soc/sof
+    cp -a tools/objtool/objtool %{buildroot}%{_devel_dir}/tools/objtool/
+    cp -a tools/objtool/fixdep %{buildroot}%{_devel_dir}/tools/objtool/
 
-# then drop all but the needed Makefiles/Kconfig files
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/include
-cp .config %{buildroot}/lib/modules/%{kverstr}/build
-cp -a scripts %{buildroot}/lib/modules/%{kverstr}/build
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts/tracing
-rm -f %{buildroot}/lib/modules/%{kverstr}/build/scripts/spdxcheck.py
+    # Install files that are needed for `make prepare` to succeed -- for x86_64
+    cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/stack.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/ctype.h %{buildroot}%{_devel_dir}
 
-%ifarch s390x
-# CONFIG_EXPOLINE_EXTERN=y produces arch/s390/lib/expoline/expoline.o
-# which is needed during external module build.
-if [ -f arch/s390/lib/expoline/expoline.o ]; then
-cp -a --parents arch/s390/lib/expoline/expoline.o %{buildroot}/lib/modules/%{kverstr}/build
-fi
-%endif
+    cp -a --parents scripts/syscalltbl.sh %{buildroot}%{_devel_dir}
+    cp -a --parents scripts/syscallhdr.sh %{buildroot}%{_devel_dir}
 
-# Files for 'make scripts' to succeed with kernel-devel.
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/security/selinux/include
-cp -a --parents security/selinux/include/classmap.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}/lib/modules/%{kverstr}/build
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/tools/include/tools
-cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
+    cp -a --parents tools/arch/x86/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/lib %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/lib/ %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/ %{buildroot}%{_devel_dir}
 
-# Files for 'make prepare' to succeed with kernel-devel.
-cp -a --parents tools/include/linux/compiler* %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux/types.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/build/Build.include %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/fixdep.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/sync-check.sh %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/bpf/resolve_btfids %{buildroot}/lib/modules/%{kverstr}/build
+    # Final cleanups ala Fedora
+    echo "Cleaning up development files..."
+    find %{buildroot}%{_devel_dir}/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    find %{buildroot}%{_devel_dir}/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    touch -r %{buildroot}%{_devel_dir}/Makefile \
+        %{buildroot}%{_devel_dir}/include/generated/uapi/linux/version.h \
+        %{buildroot}%{_devel_dir}/include/config/auto.conf
 
-cp --parents security/selinux/include/policycap_names.h %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents security/selinux/include/policycap.h %{buildroot}/lib/modules/%{kverstr}/build
+    # These links will be owned by the modules package, creating a broken
+    # link unless the -devel package is installed. why??
+    rm -rf %{buildroot}%{_kernel_dir}/build
+    ln -s %{_devel_dir} %{buildroot}%{_kernel_dir}/build
+    ln -s %{_kernel_dir}/build %{buildroot}%{_kernel_dir}/source
 
-cp -a --parents tools/include/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/vdso %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/scripts/utilities.mak %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/subcmd %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/*.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/*.[ch] %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/include/objtool/*.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/bpf %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/bpf/Build %{buildroot}/lib/modules/%{kverstr}/build
+    # Create stub initramfs to inflate disk space requirements.
+    # This should hopefully prevent some initramfs failures due to
+    # insufficient space in /boot (#bz #530778)
+    # 90 seems to be a safe value nowadays. It is slightly inflated than the
+    # measured average to also account for installed vmlinuz in /boot
+    echo "Creating stub initramfs..."
+    install -dm755 %{buildroot}/boot
+    dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{_kver}.img bs=1M count=90
 
-if [ -f tools/objtool/objtool ]; then
-  cp -a tools/objtool/objtool %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -f tools/objtool/fixdep ]; then
-  cp -a tools/objtool/fixdep %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -d arch/%{karch}/scripts ]; then
-  cp -a arch/%{karch}/scripts %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch} || :
-fi
-if [ -f arch/%{karch}/*lds ]; then
-  cp -a arch/%{karch}/*lds %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch}/ || :
-fi
-if [ -f arch/%{asmarch}/kernel/module.lds ]; then
-  cp -a --parents arch/%{asmarch}/kernel/module.lds %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-find %{buildroot}/lib/modules/%{kverstr}/build/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-%ifarch ppc64le
-cp -a --parents arch/powerpc/lib/crtsavres.[So] %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-if [ -d arch/%{asmarch}/include ]; then
-  cp -a --parents arch/%{asmarch}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-%ifarch aarch64
-# arch/arm64/include/asm/xen references arch/arm
-cp -a --parents arch/arm/include/asm/xen %{buildroot}/lib/modules/%{kverstr}/build/
-# arch/arm64/include/asm/opcodes.h references arch/arm
-cp -a --parents arch/arm/include/asm/opcodes.h %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-# include the machine specific headers for ARM variants, if available.
-%ifarch %{arm}
-if [ -d arch/%{asmarch}/mach-${Variant}/include ]; then
-  cp -a --parents arch/%{asmarch}/mach-${Variant}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-# include a few files for 'make prepare'
-cp -a --parents arch/arm/tools/gen-mach-types %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/arm/tools/mach-types %{buildroot}/lib/modules/%{kverstr}/build/
+    %if %{_build_nv}
+        cd %{_builddir}/%{_nv_pkg}
+        echo "Installing NVIDIA open kernel modules..."
+        install -Dt %{buildroot}%{_kernel_dir}/nvidia -m644 kernel-open/*.ko
+        find %{buildroot}%{_kernel_dir}/nvidia -name '*.ko' -exec zstd --rm -19 {} +
+        install -Dt %{buildroot}/%{_defaultlicensedir}/%{name}-nvidia-open -m644 COPYING
+    %endif
 
-%endif
-cp -a include %{buildroot}/lib/modules/%{kverstr}/build/include
+%package core
+Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
+AutoReq:        no
+Conflicts:      xfsprogs < 4.3.0-1
+Conflicts:      xorg-x11-drv-vmmouse < 13.0.99
+Provides:       kernel = %{_rpmver}
+Provides:       kernel-core-uname-r = %{_kver}
+Provides:       kernel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires(pre):  /usr/bin/kernel-install
+Requires(pre):  coreutils
+Requires(pre):  dracut >= 027
+Requires(pre):  systemd >= 203-2
+Requires(pre):  ((linux-firmware >= 20150904-56.git6ebf5d57) if linux-firmware)
+Requires(preun):systemd >= 200
+Recommends:     linux-firmware
 
-%ifarch i686 x86_64
-# files for 'make prepare' to succeed with kernel-devel
-cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/stack.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/ctype.h %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents scripts/syscalltbl.sh %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents scripts/syscallhdr.sh %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents tools/arch/x86/include/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/lib %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/lib/ %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/ %{buildroot}/lib/modules/%{kverstr}/build
-
-%endif
-# Clean up intermediate tools files
-find %{buildroot}/lib/modules/%{kverstr}/build/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-
-# Make sure the Makefile, version.h, and auto.conf have a matching
-# timestamp so that external modules can be built
-touch -r %{buildroot}/lib/modules/%{kverstr}/build/Makefile \
-%{buildroot}/lib/modules/%{kverstr}/build/include/generated/uapi/linux/version.h \
-%{buildroot}/lib/modules/%{kverstr}/build/include/config/auto.conf
-
-find %{buildroot}/lib/modules/%{kverstr} -name "*.ko" -type f >modnames
-
-# mark modules executable so that strip-to-file can strip them
-xargs --no-run-if-empty chmod u+x < modnames
-
-# Generate a list of modules for block and networking.
-
-grep -F /drivers/ modnames | xargs --no-run-if-empty nm -upA |
-sed -n 's,^.*/\([^/]*\.ko\):  *U \(.*\)$,\1 \2,p' > drivers.undef
-
-collect_modules_list()
-{
-  sed -r -n -e "s/^([^ ]+) \\.?($2)\$/\\1/p" drivers.undef |
-LC_ALL=C sort -u > %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  if [ ! -z "$3" ]; then
-sed -r -e "/^($3)\$/d" -i %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  fi
-}
-
-collect_modules_list networking \
-  'register_netdev|ieee80211_register_hw|usbnet_probe|phy_driver_register|rt(l_|2x00)(pci|usb)_probe|register_netdevice'
-collect_modules_list block \
-  'ata_scsi_ioctl|scsi_add_host|scsi_add_host_with_dma|blk_alloc_queue|blk_init_queue|register_mtd_blktrans|scsi_esp_register|scsi_register_device_handler|blk_queue_physical_block_size' 'pktcdvd.ko|dm-mod.ko'
-collect_modules_list drm \
-  'drm_open|drm_init'
-collect_modules_list modesetting \
-  'drm_crtc_init'
-
-# detect missing or incorrect license tags
-( find %{buildroot}/lib/modules/%{kverstr} -name '*.ko' | xargs /sbin/modinfo -l | \
-grep -E -v 'GPL( v2)?$|Dual BSD/GPL$|Dual MPL/GPL$|GPL and additional rights$' ) && exit 1
-
-remove_depmod_files()
-{
-# remove files that will be auto generated by depmod at rpm -i time
-pushd %{buildroot}/lib/modules/%{kverstr}/
-rm -f modules.{alias,alias.bin,builtin.alias.bin,builtin.bin} \
-  modules.{dep,dep.bin,devname,softdep,symbols,symbols.bin}
-popd
-}
-
-remove_depmod_files
-
-mkdir -p %{buildroot}%{_prefix}/src/kernels
-mv %{buildroot}/lib/modules/%{kverstr}/build %{buildroot}%{_prefix}/src/kernels/%{kverstr}
-
-# This is going to create a broken link during the build, but we don't use
-# it after this point.  We need the link to actually point to something
-# when kernel-devel is installed, and a relative link doesn't work across
-# the F17 UsrMove feature.
-ln -sf %{_prefix}/src/kernels/%{kverstr} %{buildroot}/lib/modules/%{kverstr}/build
-
-find %{buildroot}%{_prefix}/src/kernels -name ".*.cmd" -delete
-#
-
-cp -v System.map %{buildroot}/boot/System.map-%{kverstr}
-cp -v System.map %{buildroot}/lib/modules/%{kverstr}/System.map
-cp -v .config %{buildroot}/boot/config-%{kverstr}
-cp -v .config %{buildroot}/lib/modules/%{kverstr}/config
-
-(cd "%{buildroot}/boot/" && sha512hmac "vmlinuz-%{kverstr}" > ".vmlinuz-%{kverstr}.hmac")
-
-cp -v  %{buildroot}/boot/vmlinuz-%{kverstr} %{buildroot}/lib/modules/%{kverstr}/vmlinuz
-(cd "%{buildroot}/lib/modules/%{kverstr}" && sha512hmac vmlinuz > .vmlinuz.hmac)
-
-# create dummy initramfs image to inflate the disk space requirement for the initramfs. 48M seems to be the right size nowadays with more and more hardware requiring initramfs-located firmware to work properly (for reference, Fedora has it set to 20M)
-dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{kverstr}.img bs=1M count=48
-
-%clean
-rm -rf %{buildroot}
+%description core
+    The kernel package contains the Linux kernel (vmlinuz), the core of any
+    Linux operating system.  The kernel handles the basic functions
+    of the operating system: memory allocation, process allocation, device
+    input and output, etc.
 
 %post core
-if [ `uname -i` == "x86_64" -o `uname -i` == "i386" ] &&
-   [ -f /etc/sysconfig/kernel ]; then
-  /bin/sed -r -i -e 's/^DEFAULTKERNEL=kernel-smp$/DEFAULTKERNEL=kernel/' /etc/sysconfig/kernel || exit $?
-fi
-if [ -x /bin/kernel-install ] && [ -d /boot ]; then
-/bin/kernel-install add %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-fi
+    mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+    touch %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
 
 %posttrans core
-if [ ! -z $(rpm -qa | grep grubby) ]; then
-  grubby --set-default="/boot/vmlinuz-%{kverstr}"
-fi
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
+        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
+            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+            if command -v restorecon &>/dev/null; then
+                restorecon "/boot/symvers-%{_kver}.zst"
+            fi
+        fi
+    fi
 
 %preun core
-/bin/kernel-install remove %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-if [ -x /usr/sbin/weak-modules ]
-then
-/usr/sbin/weak-modules --remove-kernel %{kverstr} || exit $?
-fi
-
-%post devel
-if [ -f /etc/sysconfig/kernel ]
-then
-. /etc/sysconfig/kernel || exit $?
-fi
-if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]
-then
-(cd /usr/src/kernels/%{kverstr} &&
- /usr/bin/find . -type f | while read f; do
-   hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f 2>&1 >/dev/null
- done)
-fi
-
-%post modules
-/sbin/depmod -a %{kverstr}
-
-%if %{_nv_build}
-%posttrans nvidia-open
-/sbin/depmod -a %{kverstr}
-%endif
+    /bin/kernel-install remove %{_kver} || exit $?
+    if [ -x /usr/sbin/weak-modules ]; then
+        /usr/sbin/weak-modules --remove-kernel %{_kver} || exit $?
+    fi
 
 %files core
-%ghost %attr(0600, root, root) /boot/vmlinuz-%{kverstr}
-%ghost %attr(0600, root, root) /boot/System.map-%{kverstr}
-%ghost %attr(0600, root, root) /boot/initramfs-%{kverstr}.img
-%ghost %attr(0600, root, root) /boot/symvers-%{kverstr}.gz
-%ghost %attr(0644, root, root) /boot/config-%{kverstr}
-/boot/.vmlinuz-%{kverstr}.hmac
-%dir /lib/modules/%{kverstr}/
-/lib/modules/%{kverstr}/.vmlinuz.hmac
-/lib/modules/%{kverstr}/config
-/lib/modules/%{kverstr}/vmlinuz
-/lib/modules/%{kverstr}/System.map
-/lib/modules/%{kverstr}/symvers.gz
+    %dir %{_kernel_dir}
+    %license COPYING
+    %ghost /boot/initramfs-%{_kver}.img
+    %{_kernel_dir}/vmlinuz
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
+    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/config
+    %{_kernel_dir}/System.map
+
+%package modules
+Summary:        Kernel modules package for %{name}
+Provides:       kernel-modules = %{_rpmver}
+Provides:       kernel-modules-core = %{_rpmver}
+Provides:       kernel-modules-uname-r = %{_kver}
+Provides:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+
+%description modules
+    This package provides kernel modules for the %{name}-core kernel package.
+
+%post modules
+    /sbin/depmod -a %{_kver}
+    if [ ! -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver} ]; then
+        mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+        touch %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    fi
+
+%posttrans modules
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    if [ ! -e /run/ostree-booted ]; then
+        if [ -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver} ]; then
+            echo "Running: dracut -f --kver %{_kver}"
+            dracut -f --kver "%{_kver}" || exit $?
+        fi
+    fi
+
+%postun modules
+    /sbin/depmod -a %{_kver}
 
 %files modules
-/lib/modules/%{kverstr}/
-%exclude /lib/modules/%{kverstr}/.vmlinuz.hmac
-%exclude /lib/modules/%{kverstr}/config
-%exclude /lib/modules/%{kverstr}/vmlinuz
-%exclude /lib/modules/%{kverstr}/System.map
-%exclude /lib/modules/%{kverstr}/symvers.gz
-%exclude /lib/modules/%{kverstr}/build
-%exclude /lib/modules/%{kverstr}/source
-%if %{_nv_build}
-%exclude /lib/modules/%{kverstr}/nvidia
+    %{_kernel_dir}/modules.order
+    %{_kernel_dir}/build
+    %{_kernel_dir}/source
+    %{_kernel_dir}/kernel
 
-%files nvidia-open
-/lib/modules/%{kverstr}/nvidia
-/usr/share/licenses/nvidia-open/COPYING
+%package devel
+Summary:        Development package for building kernel modules to match %{name}
+Provides:       kernel-devel = %{_rpmver}
+Provides:       kernel-devel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+AutoReqProv:    no
+Requires(pre):  findutils
+Requires:       findutils
+Requires:       perl-interpreter
+Requires:       openssl-devel
+Requires:       elfutils-libelf-devel
+Requires:       bison
+Requires:       flex
+Requires:       make
+
+%if %{_build_lto}
+Requires:       clang
+Requires:       lld
+Requires:       llvm
+%else
+Requires:       gcc
 %endif
 
-%files headers
-%defattr (-, root, root)
-/usr/include/*
+%description devel
+    This package provides kernel headers and makefiles sufficient to build modules against %{name}.
+
+%post devel
+    if [ -f /etc/sysconfig/kernel ]; then
+        . /etc/sysconfig/kernel || exit $?
+    fi
+    if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]; then
+        (cd /usr/src/kernels/%{_kver} &&
+        /usr/bin/find . -type f | while read f; do
+            hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f > /dev/null
+        done;
+        )
+    fi
 
 %files devel
-%defattr (-, root, root)
-/usr/src/kernels/%{kverstr}
-/lib/modules/%{kverstr}/build
-/lib/modules/%{kverstr}/source
+    %{_devel_dir}
+
+%package devel-matched
+Summary:        Meta package to install matching core and devel packages for %{name}
+Provides:       kernel-devel-matched = %{_rpmver}
+Requires:       %{name}-core = %{_rpmver}
+Requires:       %{name}-devel = %{_rpmver}
+
+%description devel-matched
+    This meta package is used to install matching core and devel packages for %{name}.
 
 %files devel-matched
 
+%if %{_build_nv}
+%package nvidia-open
+Summary:        nvidia-open %{_nv_ver} kernel modules for %{name}
+Provides:       nvidia-kmod >= %{_nv_ver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+Conflicts:      akmod-nvidia
+Recommends:     xorg-x11-drv-nvidia >= %{_nv_ver}
+
+%description nvidia-open
+    This package provides nvidia-open %{_nv_ver} kernel modules for %{name}.
+
+%post nvidia-open
+    /sbin/depmod -a %{_kver}
+
+%files nvidia-open
+    %license %{_defaultlicensedir}/%{name}-nvidia-open/COPYING
+    %{_kernel_dir}/nvidia
+%endif
+
 %files
+
+

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -11,8 +11,8 @@
 %undefine _include_frame_pointers
 
 # Linux Kernel Versions
-%define _basekver 6.12
-%define _stablekver 10
+%define _basekver 6.13
+%define _stablekver 0
 %define _rpmver %{version}-%{release}
 %define _kver %{_rpmver}.%{_arch}
 
@@ -121,7 +121,7 @@ Source10:       https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_
 
 Patch0:         %{_patch_src}/all/0001-cachyos-base-all.patch
 Patch1:         %{_patch_src}/sched/0001-bore-cachy.patch
-Patch2:         %{_patch_src}/misc/0001-rt.patch
+Patch2:         %{_patch_src}/misc/0001-rt-i915.patch
 
 %if %{_build_lto}
 Patch2:         %{_patch_src}/misc/dkms-clang.patch
@@ -132,6 +132,11 @@ Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-en
 Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
 Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
 Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+Patch14:        %{_patch_src}/misc/nvidia/0006-crypto-Add-fix-for-6.13-Module-compilation.patch
+Patch15:        %{_patch_src}/misc/nvidia/0007-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch
+Patch16:        %{_patch_src}/misc/nvidia/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch
+Patch17:        %{_patch_src}/misc/nvidia/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch
+Patch18:        %{_patch_src}/misc/nvidia/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch
 %endif
 
 %description
@@ -156,7 +161,7 @@ Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-n
     scripts/config -u DEFAULT_HOSTNAME
 
     # Enable PREEMPT_RT
-    scripts/config -d PREEMPT_DYNAMIC -d PREEMPT
+    scripts/config -e PREEMPT_LAZY
     scripts/config -e PREEMPT_RT
 
     case %{_hz_tick} in

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -74,7 +74,6 @@ Requires:       kernel-core-uname-r = %{_kver}
 Requires:       kernel-modules-uname-r = %{_kver}
 Requires:       kernel-modules-core-uname-r = %{_kver}
 Provides:       installonlypkg(kernel)
-Provides:       kernel-uname-r = %{_kver}
 
 BuildRequires:  bc
 BuildRequires:  bison
@@ -318,12 +317,20 @@ Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-n
 
 %package core
 Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
+AutoReq:        no
+Conflicts:      xfsprogs < 4.3.0-1
+Conflicts:      xorg-x11-drv-vmmouse < 13.0.99
 Provides:       kernel-core-uname-r = %{_kver}
+Provides:       kernel-uname-r = %{_kver}
 Provides:       installonlypkg(kernel)
 Requires:       kernel-modules-uname-r = %{_kver}
-Requires:       coreutils
-Requires:       dracut
-Requires:       kmod
+Requires(pre):  /usr/bin/kernel-install
+Requires(pre):  coreutils
+Requires(pre):  dracut >= 027
+Requires(pre):  systemd >= 203-2
+Requires(pre):  ((linux-firmware >= 20150904-56.git6ebf5d57) if linux-firmware)
+Requires(preun):systemd >= 200
+Recommends:     linux-firmware
 
 %description core
     The kernel package contains the Linux kernel (vmlinuz), the core of any

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -307,6 +307,17 @@ Requires:       gcc
 %files devel
     %{_devel_dir}
 
+%package devel-matched
+Summary:        Meta package to install matching core and devel packages for %{name}
+Provides:       kernel-devel-matched = %{_rpmver}
+Requires:       %{name}-core = %{_rpmver}
+Requires:       %{name}-devel = %{_rpmver}
+
+%description devel-matched
+    This meta package is used to install matching core and devel packages for %{name}.
+
+%files devel-matched
+
 %files
 
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos3%{?_lto_args:.lto}%{?dist}
+Release:        cachyos4%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -320,6 +320,7 @@ Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and 
 AutoReq:        no
 Conflicts:      xfsprogs < 4.3.0-1
 Conflicts:      xorg-x11-drv-vmmouse < 13.0.99
+Provides:       kernel = %{_rpmver}
 Provides:       kernel-core-uname-r = %{_kver}
 Provides:       kernel-uname-r = %{_kver}
 Provides:       installonlypkg(kernel)
@@ -372,7 +373,9 @@ Recommends:     linux-firmware
     %{_kernel_dir}/System.map
 
 %package modules
-Summary:        Kernel modules package for %{name}.
+Summary:        Kernel modules package for %{name}
+Provides:       kernel-modules = %{_rpmver}
+Provides:       kernel-modules-core = %{_rpmver}
 Provides:       kernel-modules-uname-r = %{_kver}
 Provides:       kernel-modules-core-uname-r = %{_kver}
 Provides:       installonlypkg(kernel-module)
@@ -408,6 +411,7 @@ Requires:       kernel-uname-r = %{_kver}
 
 %package devel
 Summary:        Development package for building kernel modules to match %{name}
+Provides:       kernel-devel = %{_rpmver}
 Provides:       kernel-devel-uname-r = %{_kver}
 Provides:       installonlypkg(kernel)
 AutoReqProv:    no

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -11,8 +11,8 @@
 %undefine _include_frame_pointers
 
 # Linux Kernel Versions
-%define _basekver 6.12
-%define _stablekver 10
+%define _basekver 6.13
+%define _stablekver 0
 %define _rpmver %{version}-%{release}
 %define _kver %{_rpmver}.%{_arch}
 
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos4%{?_lto_args:.lto}%{?dist}
+Release:        cachyos1%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -131,6 +131,11 @@ Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-en
 Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
 Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
 Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+Patch14:        %{_patch_src}/misc/nvidia/0006-crypto-Add-fix-for-6.13-Module-compilation.patch
+Patch15:        %{_patch_src}/misc/nvidia/0007-nvidia-nv-Convert-symbol-namespace-to-string-literal.patch
+Patch16:        %{_patch_src}/misc/nvidia/0008-Kbuild-Use-absolute-paths-for-symbolic-links.patch
+Patch17:        %{_patch_src}/misc/nvidia/0009-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch
+Patch18:        %{_patch_src}/misc/nvidia/0010-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch
 %endif
 
 %description

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -36,6 +36,12 @@
 %define _nv_ver 565.77
 %define _nv_pkg open-gpu-kernel-modules-%{_nv_ver}
 
+# Define the tickrate used by the kernel
+# Valid values: 100, 250, 300, 500, 600, 750 and 1000
+# An invalid value will not fail and continue to use
+# 1000Hz tickrate.
+%define _hz_tick 1000
+
 # Define variables for directory paths
 # to be used during packaging
 %define _kernel_dir /lib/modules/%{_kver}
@@ -143,12 +149,17 @@ Patch13:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/
     # Must always enable configs
     scripts/config -e CACHY
     scripts/config -e SCHED_BORE
-    scripts/config -d HZ_300
-    scripts/config -e HZ_1000
-    scripts/config --set-val HZ 1000
     scripts/config --set-val X86_64_VERSION 3
     scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
     scripts/config -u DEFAULT_HOSTNAME
+
+    case %{_hz_tick} in
+        100|250|300|500|600|750|1000)
+            scripts/config -e HZ_%{_hz_tick} --set-val HZ %{_hz_tick};;
+        *)
+            echo "Invalid tickrate value, using default 1000"
+            scripts/config -e HZ_1000 --set-val HZ 1000;;
+    esac
 
     %if %{_build_lto}
         scripts/config -e LTO_CLANG_THIN

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -54,6 +54,8 @@
 %define _kernel_dir /lib/modules/%{_kver}
 %define _devel_dir /usr/src/kernels/%{_kver}
 
+%define _patch_src https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}
+
 %if %{_build_lto}
     # Define build environment variables to build the kernel with clang
     %define _build_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
@@ -125,18 +127,18 @@ Source2:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/m
 Source10:       https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_pkg}.tar.gz
 %endif
 
-Patch0:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
+Patch0:         %{_patch_src}/all/0001-cachyos-base-all.patch
+Patch1:         %{_patch_src}/sched/0001-bore-cachy.patch
 
 %if %{_build_lto}
-Patch2:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/dkms-clang.patch
+Patch2:         %{_patch_src}/misc/dkms-clang.patch
 %endif
 
 %if %{_build_nv}
-Patch10:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch
-Patch11:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
-Patch12:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0004-silence-event-assert-until-570.patch
-Patch13:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
+Patch10:        %{_patch_src}/misc/nvidia/0001-Make-modeset-and-fbdev-default-enabled.patch
+Patch11:        %{_patch_src}/misc/nvidia/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
+Patch12:        %{_patch_src}/misc/nvidia/0004-silence-event-assert-until-570.patch
+Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
 %endif
 
 %description

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -42,6 +42,13 @@
 # 1000Hz tickrate.
 %define _hz_tick 1000
 
+# Defines the x86_64 ISA level used
+# to compile the kernel
+# Valid values are 1-4
+# An invalid value will continue and use
+# x86_64_v3
+%define _x86_64_lvl 3
+
 # Define variables for directory paths
 # to be used during packaging
 %define _kernel_dir /lib/modules/%{_kver}
@@ -149,7 +156,6 @@ Patch13:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/
     # Must always enable configs
     scripts/config -e CACHY
     scripts/config -e SCHED_BORE
-    scripts/config --set-val X86_64_VERSION 3
     scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
     scripts/config -u DEFAULT_HOSTNAME
 
@@ -160,6 +166,13 @@ Patch13:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/
             echo "Invalid tickrate value, using default 1000"
             scripts/config -e HZ_1000 --set-val HZ 1000;;
     esac
+
+    %if %{_x86_64_lvl} < 5 && %{_x86_64_lvl} > 0
+        scripts/config --set-val X86_64_VERSION %{_x86_64_lvl}
+    %else
+        echo "Invalid x86_64 ISA Level. Using x86_64_v3"
+        scripts/config --set-val X86_64_VERSION 3
+    %endif
 
     %if %{_build_lto}
         scripts/config -e LTO_CLANG_THIN

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -1,744 +1,304 @@
-### A port of linux-cachyos (https://github.com/CachyOS/linux-cachyos/tree/master/linux-cachyos) for the Fedora operating system.
-# https://github.com/CachyOS/linux-cachyos
-### The authors of linux-cachyos patchset:
-# Peter Jung ptr1337 <admin@ptr1337.dev>
-# Piotr Gorski sirlucjan <piotrgorski@cachyos.org>
-### The author of BORE-EEVDF Scheduler:
-# Masahito Suzuki <firelzrd@gmail.com>
-### The port maintainer for Fedora:
-# bieszczaders <zbyszek@linux.pl>
-# https://copr.fedorainfracloud.org/coprs/bieszczaders/
+# Maintainer: Eric Naim <dnaim@cachyos.org>
 
-%define _build_id_links none
+# Fedora bits
+%define __spec_install_post /usr/lib/rpm/brp-compress || :
+%define _default_patch_fuzz 2
 %define _disable_source_fetch 0
-
-# See https://fedoraproject.org/wiki/Changes/SetBuildFlagsBuildCheck to why this has to be done
-%if 0%{?fedora} >= 37
+%define debug_package %{nil}
 %undefine _auto_set_build_flags
-%endif
+%undefine _include_frame_pointers
 
-%ifarch x86_64
-%define karch x86
-%define asmarch x86
-%endif
-
-# define git branch to make testing easier without merging to master branch
-%define _git_branch master
-
-# whether to build kernel with llvm compiler(clang)
-%define llvm_kbuild 0
-%if %{llvm_kbuild}
-%define llvm_build_env_vars CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
-%define ltoflavor 1
-%endif
-
-%define flavor cachyos
-Name: kernel%{?flavor:-%{flavor}}%{?ltoflavor:-lto}
-Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
-
+# Linux Kernel Versions
 %define _basekver 6.12
 %define _stablekver 9
-%if %{_stablekver} == 0
-%define _tarkver %{_basekver}
-%else
-%define _tarkver %{_basekver}.%{_stablekver}
-%endif
+%define _rpmver %{version}-%{release}
+%define _kver %{_rpmver}.%{_arch}
 
-Version: %{_basekver}.%{_stablekver}
+# Define variables for directory paths
+# to be used during packaging
+%define _kernel_dir /lib/modules/%{_kver}
+%define _devel_dir /usr/src/kernels/%{_kver}
 
-%define customver 1
-%define flaver cb%{customver}
+Name:           kernel-cachyos
+Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements.
+Version:        %{_basekver}.%{_stablekver}
+Release:        cachyos5%{?dist}
+License:        GPL-2.0-Only
+URL:            https://cachyos.org
 
-Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
+Requires:       kernel-core-uname-r = %{_kver}
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+Provides:       kernel-uname-r = %{_kver}
 
-# Define rawhide fedora version
-%define _rawhidever 42
+BuildRequires:  bc
+BuildRequires:  bison
+BuildRequires:  cpio
+BuildRequires:  dwarves
+BuildRequires:  elfutils-devel
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  gettext-devel
+BuildRequires:  kernel-rpm-macros
+BuildRequires:  kmod
+BuildRequires:  make
+BuildRequires:  openssl
+BuildRequires:  openssl-devel
+BuildRequires:  perl-Carp
+BuildRequires:  perl-devel,
+BuildRequires:  perl-generators
+BuildRequires:  perl-interpreter
+BuildRequires:  python3-devel
+BuildRequires:  python3-pyyaml
+BuildRequires:  redhat-rpm-config
+BuildRequires:  tar
+BuildRequires:  xz
+BuildRequires:  zstd
 
-# Build nvidia-open alongside the kernel
-%define _nv_build 1
-%if 0%{?fedora} >= 41
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%else
-%define _nv_ver 565.77
-%define _nvidia_patchurl https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia
-%endif
-%define _nv_open_pkg open-gpu-kernel-modules-%{_nv_ver}
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{version}.tar.xz
+#Source0:       https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%_basekver.tar.xz
+Source1:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/config
 
-%define rpmver %{version}-%{release}
-%define krelstr %{release}.%{_arch}
-%define kverstr %{version}-%{krelstr}
-
-License: GPLv2 and Redistributable, no modifications permitted
-Group: System Environment/Kernel
-Vendor: The Linux Community and CachyOS maintainer(s)
-URL: https://cachyos.org
-Source0: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
-Source1: https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/config
-Source2: https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{_nv_ver}/%{_nv_open_pkg}.tar.gz
-# Stable patches
-Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
-Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
-
-Patch3: %{_nvidia_patchurl}/0001-Make-modeset-and-fbdev-default-enabled.patch
-Patch4: %{_nvidia_patchurl}/0004-silence-event-assert-until-570.patch
-Patch5: %{_nvidia_patchurl}/0002-Do-not-error-on-unkown-CPU-Type-and-add-Zen5-support.patch
-Patch6: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-name-strings.patch
-
-# Dev patches
-#Patch0: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all-dev.patch
-#Patch1: https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched-dev/0001-bore-cachy.patch
-%define __spec_install_post /usr/lib/rpm/brp-compress || :
-%define debug_package %{nil}
-BuildRequires: python3-devel
-BuildRequires: make
-BuildRequires: perl-generators
-BuildRequires: perl-interpreter
-BuildRequires: openssl-devel
-BuildRequires: bison
-BuildRequires: flex
-BuildRequires: findutils
-BuildRequires: git-core
-BuildRequires: perl-devel
-BuildRequires: openssl
-BuildRequires: elfutils-devel
-BuildRequires: gawk
-BuildRequires: binutils
-BuildRequires: m4
-BuildRequires: tar
-BuildRequires: hostname
-BuildRequires: bzip2
-BuildRequires: bash
-BuildRequires: gzip
-BuildRequires: xz
-BuildRequires: bc
-BuildRequires: diffutils
-BuildRequires: redhat-rpm-config
-BuildRequires: net-tools
-BuildRequires: elfutils
-BuildRequires: patch
-BuildRequires: rpm-build
-BuildRequires: dwarves
-BuildRequires: kmod
-BuildRequires: libkcapi-hmaccalc
-BuildRequires: perl-Carp
-BuildRequires: rsync
-BuildRequires: grubby
-BuildRequires: wget
-BuildRequires: gcc
-BuildRequires: gcc-c++
-%if %{llvm_kbuild}
-BuildRequires: llvm
-BuildRequires: clang
-BuildRequires: lld
-%endif
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore <= 6.5.10-cb1
+Patch0:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/all/0001-cachyos-base-all.patch
+Patch1:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}/sched/0001-bore-cachy.patch
 
 %description
-The kernel-%{flaver} meta package
+    The meta package for %{name}.
 
-%package core
-Summary: Kernel core package
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel)
-Provides: kernel = %{rpmver}
-Provides: kernel-core = %{rpmver}
-Provides: kernel-core-uname-r = %{kverstr}
-Provides: kernel-uname-r = %{kverstr}
-Provides: kernel-%{_arch} = %{rpmver}
-Provides: kernel-core%{_isa} = %{rpmver}
-Provides: kernel-core-%{rpmver} = %{kverstr}
-Provides: %{name}-core-%{rpmver} = %{kverstr}
-Provides:  kernel-drm-nouveau = 16
-# multiver
-Provides: %{name}%{_basekver}-core = %{rpmver}
-Requires: bash
-Requires: coreutils
-Requires: dracut
-Requires: linux-firmware
-Requires: /usr/bin/kernel-install
-Requires: kernel-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-core >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-core >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-core <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-core <= 6.5.10-cb1
-%description core
-The kernel package contains the Linux kernel (vmlinuz), the core of any
-Linux operating system.  The kernel handles the basic functions
-of the operating system: memory allocation, process allocation, device
-input and output, etc.
-
-%package modules
-Summary: Kernel modules to match the core kernel
-Group: System Environment/Kernel
-Provides: installonlypkg(kernel-module)
-Provides: %{name}%{_basekver}-modules = %{rpmver}
-Provides: kernel-modules = %{rpmver}
-Provides: kernel-modules%{_isa} = %{rpmver}
-Provides: kernel-modules-uname-r = %{kverstr}
-Provides: kernel-modules-%{_arch} = %{rpmver}
-Provides: kernel-modules-%{rpmver} = %{kverstr}
-Provides: %{name}-modules-%{rpmver} = %{kverstr}
-Supplements: %{name} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-modules >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-modules >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-modules <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-modules <= 6.5.10-cb1
-%description modules
-This package provides kernel modules for the core %{?flavor:%{flavor}} kernel package.
-
-%if %{_nv_build}
-%package nvidia-open
-Summary: Prebuilt nvidia-open kernel modules to match the core kernel
-Group: System Environment/Kernel
-Requires: %{name}-core-%{rpmver} = %{kverstr}
-Requires: %{name}-modules-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver} = %{rpmver}
-Provides: nvidia-kmod >= %{_nv_ver}
-Provides: installonlypkg(kernel-module)
-Conflicts: akmod-nvidia
-Recommends: xorg-x11-drv-nvidia >= %{_nv_ver}
-%description nvidia-open
-This package provides prebuilt nvidia-open kernel modules for the core %{?flavor:%{flavor}} kernel package.
-%endif
-
-%package headers
-Summary: Header files for the Linux kernel for use by glibc
-Group: Development/System
-Provides: kernel-headers = %{kverstr}
-Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers%{_isa} = %{kverstr}
-Obsoletes: kernel-headers < %{kverstr}
-Obsoletes: glibc-kernheaders < 3.0-46
-Obsoletes: kernel-cachyos-bore-eevdf-headers <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-headers <= 6.5.10-cb1
-Provides: kernel-cachyos-bore-eevdf-headers >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-headers >= 6.5.7-cb1
-%description headers
-Kernel-headers includes the C header files that specify the interface
-between the Linux kernel and userspace libraries and programs.  The
-header files define structures and constants that are needed for
-building most standard programs and are also needed for rebuilding the
-glibc package.
-
-%package devel
-Summary: Development package for building kernel modules to match the %{?flavor:%{flavor}} kernel
-Group: System Environment/Kernel
-AutoReqProv: no
-Requires: findutils
-Requires: perl-interpreter
-Requires: openssl-devel
-Requires: flex
-Requires: make
-Requires: bison
-Requires: elfutils-libelf-devel
-Requires: gcc
-%if %{llvm_kbuild}
-Requires: clang
-Requires: llvm
-Requires: lld
-%endif
-Enhances: akmods
-Enhances: dkms
-Provides: installonlypkg(kernel)
-Provides: kernel-devel = %{rpmver}
-Provides: kernel-devel-uname-r = %{kverstr}
-Provides: kernel-devel-%{_arch} = %{rpmver}
-Provides: kernel-devel%{_isa} = %{rpmver}
-Provides: kernel-devel-%{rpmver} = %{kverstr}
-Provides: %{name}-devel-%{rpmver} = %{kverstr}
-Provides: %{name}%{_basekver}-devel = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-devel >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-devel >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-devel <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-devel <= 6.5.10-cb1
-%description devel
-This package provides kernel headers and makefiles sufficient to build modules
-against the %{?flavor:%{flavor}} kernel package.
-
-%package devel-matched
-Summary: Meta package to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel
-Requires: %{name}-devel = %{rpmver},
-Requires: %{name}-core = %{rpmver}
-Provides: kernel-devel-matched = %{rpmver}
-Provides: kernel-devel-matched%{_isa} = %{rpmver}
-Provides: kernel-cachyos-bore-eevdf-devel-matched >= 6.5.7-cbe1
-Provides: kernel-cachyos-bore-devel-matched >= 6.5.7-cb1
-Obsoletes: kernel-cachyos-bore-eevdf-devel-matched <= 6.5.10-cbe1
-Obsoletes: kernel-cachyos-bore-devel-matched <= 6.5.10-cb1
-%description devel-matched
-This meta package is used to install matching core and devel packages for a given %{?flavor:%{flavor}} kernel.
 
 %prep
-%setup -q -n linux-%{_tarkver}
+    %setup -q -n linux-%{version}
+    %autopatch -p1 -v -M 9
 
-tar -xzf %{SOURCE2} -C %{_builddir}
+    cp %{SOURCE1} .config
 
-# Apply CachyOS patch
-patch -p1 -i %{PATCH0}
+    # Must always enable configs
+    scripts/config -e CACHY
+    scripts/config -e SCHED_BORE
+    scripts/config -d HZ_300
+    scripts/config -e HZ_1000
+    scripts/config --set-val HZ 1000
+    scripts/config --set-val X86_64_VERSION 3
+    scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
+    scripts/config -u DEFAULT_HOSTNAME
 
-# Apply EEVDF and BORE patches
-patch -p1 -i %{PATCH1}
-
-### Apply patches for nvidia-open
-# Set modeset and fbdev to default enabled
-patch -p1 -i %{PATCH3} -d %{_builddir}/%{_nv_open_pkg}/kernel-open
-# Silence Assert warnings
-patch -p1 -i %{PATCH4} -d %{_builddir}/%{_nv_open_pkg}/
-# Fix for Zen5 error print in dmesg
-patch -p1 -i %{PATCH5} -d %{_builddir}/%{_nv_open_pkg}/
-# Patches for Nvidia on kernel 6.12
-patch -p1 -i %{PATCH6} -d %{_builddir}/%{_nv_open_pkg}/
-
-
-# Fetch the config and move it to the proper directory
-cp %{SOURCE1} .config
-
-# Remove CachyOS's localversion
-find . -name "localversion*" -delete
-scripts/config -u LOCALVERSION
-
-# Enable CachyOS tweaks
-scripts/config -e CACHY
-
-# Enable BORE Scheduler
-scripts/config -e SCHED_BORE
-
-# Enable sched-ext
-scripts/config -e SCHED_CLASS_EXT
-scripts/config -e BPF
-scripts/config -e BPF_EVENTS
-scripts/config -e BPF_JIT
-scripts/config -e BPF_SYSCALL
-scripts/config -e DEBUG_INFO
-scripts/config -e DEBUG_INFO_BTF
-scripts/config -e DEBUG_INFO_BTF_MODULES
-scripts/config -e FTRACE
-scripts/config -e PAHOLE_HAS_SPLIT_BTF
-scripts/config -e DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT
-scripts/config -e SCHED_DEBUG
-
-# Setting tick rate
-scripts/config -d HZ_300
-scripts/config -e HZ_1000
-scripts/config --set-val HZ 1000
-
-# Enable x86_64_v3
-# Just to be sure, check:
-# /lib/ld-linux-x86-64.so.2 --help | grep supported
-# and make sure if your processor supports it:
-# x86-64-v3 (supported, searched)
-scripts/config --set-val X86_64_VERSION 3
-
-# Set O3
-scripts/config -d CC_OPTIMIZE_FOR_PERFORMANCE
-scripts/config -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
-
-# Enable full ticks
-scripts/config -d HZ_PERIODIC
-scripts/config -d NO_HZ_IDLE
-scripts/config -d CONTEXT_TRACKING_FORCE
-scripts/config -e NO_HZ_FULL_NODEF
-scripts/config -e NO_HZ_FULL
-scripts/config -e NO_HZ
-scripts/config -e NO_HZ_COMMON
-scripts/config -e CONTEXT_TRACKING
-
-# Enable full preempt
-scripts/config -e PREEMPT_BUILD
-scripts/config -d PREEMPT_NONE
-scripts/config -d PREEMPT_VOLUNTARY
-scripts/config -e PREEMPT
-scripts/config -e PREEMPT_COUNT
-scripts/config -e PREEMPTION
-scripts/config -e PREEMPT_DYNAMIC
-
-# Enable thin lto
-%if %{llvm_kbuild}
-scripts/config -e LTO
-scripts/config -e LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG
-scripts/config -e ARCH_SUPPORTS_LTO_CLANG_THIN
-scripts/config -d LTO_NONE
-scripts/config -e HAS_LTO_CLANG
-scripts/config -d LTO_CLANG_FULL
-scripts/config -e LTO_CLANG_THIN
-scripts/config -e HAVE_GCC_PLUGINS
-%endif
-
-# Unset hostname
-scripts/config -u DEFAULT_HOSTNAME
-
-# Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
-
-# Set kernel version string as build salt
-scripts/config --set-str BUILD_SALT "%{kverstr}"
-
-# Finalize the patched config
-#make %{?_smp_mflags} EXTRAVERSION=-%{krelstr} oldconfig
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr} olddefconfig
-
-# Save configuration for later reuse
-cat .config > config-linux-bore
+    make olddefconfig
+    diff -u %{SOURCE1} .config || :
 
 %build
-make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr}
-%if %{llvm_kbuild}
-clang ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%else
-gcc ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%endif
-
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-CFLAGS= CXXFLAGS= LDFLAGS= make %{?llvm_build_env_vars} KERNEL_UNAME=%{kverstr} IGNORE_PREEMPT_RT_PRESENCE=1 IGNORE_CC_MISMATCH=yes SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver} %{?_smp_mflags} modules
-%endif
+    make %{?_smp_mflags} EXTRAVERSION=-%{release}.%{_arch} all
+    make -C tools/bpf/bpftool vmlinux.h feature-clang-bpf-co-re=1
 
 %install
+    install -Dm644 "$(make -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
+    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
 
-ImageName=$(make image_name | tail -n 1)
+    # Modules
+    ZSTD_CLEVEL=19 make %{?_smp_mflags} INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
 
-mkdir -p %{buildroot}/boot
+    # -devel files
+    install -Dt %{buildroot}%{_devel_dir} -m644 .config Makefile Module.symvers System.map tools/bpf/bpftool/vmlinux.h
+    cp .config %{buildroot}%{_kernel_dir}/config
+    cp System.map %{buildroot}%{_kernel_dir}/System.map
+    cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts
+    rm -rf %{buildroot}%{_devel_dir}/include
+    cp -a scripts %{buildroot}%{_devel_dir}
+    rm -rf %{buildroot}%{_devel_dir}/scripts/tracing
+    rm -f %{buildroot}%{_devel_dir}/scripts/spdxcheck.py
 
-cp -v $ImageName %{buildroot}/boot/vmlinuz-%{kverstr}
-chmod 755 %{buildroot}/boot/vmlinuz-%{kverstr}
+    # The cp commands below are needed for parity with Fedora's packaging
+    # Install files that are needed for `make scripts` to succeed
+    cp -a --parents security/selinux/include/classmap.h %{buildroot}%{_devel_dir}
+    cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}%{_devel_dir}
 
-ZSTD_CLEVEL=19 make %{?_smp_mflags} %{?llvm_build_env_vars} INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_STRIP=1 modules_install mod-fw=
-make %{?_smp_mflags} %{?llvm_build_env_vars} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
+    # Install files that are needed for `make prepare` to succeed -- Generic
+    cp -a --parents tools/include/linux/compiler* %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux/types.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/build/Build.include %{buildroot}%{_devel_dir}
+    cp --parents tools/build/fixdep.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/sync-check.sh %{buildroot}%{_devel_dir}
+    cp -a --parents tools/bpf/resolve_btfids %{buildroot}%{_devel_dir}
 
-%if %{_nv_build}
-cd %{_builddir}/%{_nv_open_pkg}
-install -dm755 "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/nvidia"
-install -Dt "%{buildroot}/usr/share/licenses/nvidia-open" -m644 COPYING
-find "%{buildroot}" -name '*.ko' -exec zstd --rm -19 {} +
-%endif
+    cp --parents security/selinux/include/policycap_names.h %{buildroot}%{_devel_dir}
+    cp --parents security/selinux/include/policycap.h %{buildroot}%{_devel_dir}
 
-# prepare -devel files
-### all of the things here are derived from the Fedora kernel.spec
-### see
-##### https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec
-cd %{_builddir}/linux-%{_tarkver}
-rm -f %{buildroot}/lib/modules/%{kverstr}/build
-rm -f %{buildroot}/lib/modules/%{kverstr}/source
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build
-(cd %{buildroot}/lib/modules/%{kverstr} ; ln -s build source)
-# dirs for additional modules per module-init-tools, kbuild/modules.txt
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/updates
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/weak-updates
-# CONFIG_KERNEL_HEADER_TEST generates some extra files in the process of
-# testing so just delete
-find . -name *.h.s -delete
-# first copy everything
-cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %{buildroot}/lib/modules/%{kverstr}/build
-if [ ! -e Module.symvers ]; then
-touch Module.symvers
-fi
-cp Module.symvers %{buildroot}/lib/modules/%{kverstr}/build
-cp System.map %{buildroot}/lib/modules/%{kverstr}/build
-if [ -s Module.markers ]; then
-cp Module.markers %{buildroot}/lib/modules/%{kverstr}/build
-fi
+    cp -a --parents tools/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/asm-generic %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/uapi/linux %{buildroot}%{_devel_dir}
+    cp -a --parents tools/include/vdso %{buildroot}%{_devel_dir}
+    cp --parents tools/scripts/utilities.mak %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/subcmd %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/*.c %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/*.[ch] %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/Build %{buildroot}%{_devel_dir}
+    cp --parents tools/objtool/include/objtool/*.h %{buildroot}%{_devel_dir}
+    cp -a --parents tools/lib/bpf %{buildroot}%{_devel_dir}
+    cp --parents tools/lib/bpf/Build %{buildroot}%{_devel_dir}
 
-# create the kABI metadata for use in packaging
-# NOTENOTE: the name symvers is used by the rpm backend
-# NOTENOTE: to discover and run the /usr/lib/rpm/fileattrs/kabi.attr
-# NOTENOTE: script which dynamically adds exported kernel symbol
-# NOTENOTE: checksums to the rpm metadata provides list.
-# NOTENOTE: if you change the symvers name, update the backend too
-echo "**** GENERATING kernel ABI metadata ****"
-gzip -c9 < Module.symvers > %{buildroot}/boot/symvers-%{kverstr}.gz
-cp %{buildroot}/boot/symvers-%{kverstr}.gz %{buildroot}/lib/modules/%{kverstr}/symvers.gz
+    # Misc headers
+    cp -a --parents arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include %{buildroot}%{_devel_dir}
+    cp -a include %{buildroot}%{_devel_dir}/include
+    cp -a sound/soc/sof/sof-audio.h %{buildroot}%{_devel_dir}/sound/soc/sof
+    cp -a tools/objtool/objtool %{buildroot}%{_devel_dir}/tools/objtool/
+    cp -a tools/objtool/fixdep %{buildroot}%{_devel_dir}/tools/objtool/
 
-# then drop all but the needed Makefiles/Kconfig files
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/include
-cp .config %{buildroot}/lib/modules/%{kverstr}/build
-cp -a scripts %{buildroot}/lib/modules/%{kverstr}/build
-rm -rf %{buildroot}/lib/modules/%{kverstr}/build/scripts/tracing
-rm -f %{buildroot}/lib/modules/%{kverstr}/build/scripts/spdxcheck.py
+    # Install files that are needed for `make prepare` to succeed -- for x86_64
+    cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/tools/relocs.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/stack.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.h %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/string.c %{buildroot}%{_devel_dir}
+    cp -a --parents arch/x86/boot/ctype.h %{buildroot}%{_devel_dir}
 
-%ifarch s390x
-# CONFIG_EXPOLINE_EXTERN=y produces arch/s390/lib/expoline/expoline.o
-# which is needed during external module build.
-if [ -f arch/s390/lib/expoline/expoline.o ]; then
-cp -a --parents arch/s390/lib/expoline/expoline.o %{buildroot}/lib/modules/%{kverstr}/build
-fi
-%endif
+    cp -a --parents scripts/syscalltbl.sh %{buildroot}%{_devel_dir}
+    cp -a --parents scripts/syscallhdr.sh %{buildroot}%{_devel_dir}
 
-# Files for 'make scripts' to succeed with kernel-devel.
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/security/selinux/include
-cp -a --parents security/selinux/include/classmap.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents security/selinux/include/initial_sid_to_string.h %{buildroot}/lib/modules/%{kverstr}/build
-mkdir -p %{buildroot}/lib/modules/%{kverstr}/build/tools/include/tools
-cp -a --parents tools/include/tools/be_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/tools/le_byteshift.h %{buildroot}/lib/modules/%{kverstr}/build
+    cp -a --parents tools/arch/x86/include/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/lib %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/lib/ %{buildroot}%{_devel_dir}
+    cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}%{_devel_dir}
+    cp -a --parents tools/objtool/arch/x86/ %{buildroot}%{_devel_dir}
 
-# Files for 'make prepare' to succeed with kernel-devel.
-cp -a --parents tools/include/linux/compiler* %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux/types.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/build/Build.include %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/build/fixdep.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/sync-check.sh %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/bpf/resolve_btfids %{buildroot}/lib/modules/%{kverstr}/build
+    # Final cleanups ala Fedora
+    find %{buildroot}%{_devel_dir}/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    find %{buildroot}%{_devel_dir}/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
+    touch -r %{buildroot}%{_devel_dir}/Makefile \
+        %{buildroot}%{_devel_dir}/include/generated/uapi/linux/version.h \
+        %{buildroot}%{_devel_dir}/include/config/auto.conf
 
-cp --parents security/selinux/include/policycap_names.h %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents security/selinux/include/policycap.h %{buildroot}/lib/modules/%{kverstr}/build
+    # These links will be owned by the modules package, creating a broken
+    # link unless the -devel package is installed. why??
+    rm -rf %{buildroot}%{_kernel_dir}/build
+    ln -s %{_devel_dir} %{buildroot}%{_kernel_dir}/build
+    ln -s %{_kernel_dir}/build %{buildroot}%{_kernel_dir}/source
 
-cp -a --parents tools/include/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/asm-generic %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/uapi/linux %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/include/vdso %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/scripts/utilities.mak %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/subcmd %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/*.c %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/*.[ch] %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/Build %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/objtool/include/objtool/*.h %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/lib/bpf %{buildroot}/lib/modules/%{kverstr}/build
-cp --parents tools/lib/bpf/Build %{buildroot}/lib/modules/%{kverstr}/build
+%package core
+Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
+Provides:       kernel-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+Requires:       kernel-modules-uname-r = %{_kver}
+Requires:       coreutils
+Requires:       dracut
+Requires:       kmod
 
-if [ -f tools/objtool/objtool ]; then
-  cp -a tools/objtool/objtool %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -f tools/objtool/fixdep ]; then
-  cp -a tools/objtool/fixdep %{buildroot}/lib/modules/%{kverstr}/build/tools/objtool/ || :
-fi
-if [ -d arch/%{karch}/scripts ]; then
-  cp -a arch/%{karch}/scripts %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch} || :
-fi
-if [ -f arch/%{karch}/*lds ]; then
-  cp -a arch/%{karch}/*lds %{buildroot}/lib/modules/%{kverstr}/build/arch/%{_arch}/ || :
-fi
-if [ -f arch/%{asmarch}/kernel/module.lds ]; then
-  cp -a --parents arch/%{asmarch}/kernel/module.lds %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-find %{buildroot}/lib/modules/%{kverstr}/build/scripts \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-%ifarch ppc64le
-cp -a --parents arch/powerpc/lib/crtsavres.[So] %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-if [ -d arch/%{asmarch}/include ]; then
-  cp -a --parents arch/%{asmarch}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-%ifarch aarch64
-# arch/arm64/include/asm/xen references arch/arm
-cp -a --parents arch/arm/include/asm/xen %{buildroot}/lib/modules/%{kverstr}/build/
-# arch/arm64/include/asm/opcodes.h references arch/arm
-cp -a --parents arch/arm/include/asm/opcodes.h %{buildroot}/lib/modules/%{kverstr}/build/
-%endif
-# include the machine specific headers for ARM variants, if available.
-%ifarch %{arm}
-if [ -d arch/%{asmarch}/mach-${Variant}/include ]; then
-  cp -a --parents arch/%{asmarch}/mach-${Variant}/include %{buildroot}/lib/modules/%{kverstr}/build/
-fi
-# include a few files for 'make prepare'
-cp -a --parents arch/arm/tools/gen-mach-types %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/arm/tools/mach-types %{buildroot}/lib/modules/%{kverstr}/build/
-
-%endif
-cp -a include %{buildroot}/lib/modules/%{kverstr}/build/include
-
-%ifarch i686 x86_64
-# files for 'make prepare' to succeed with kernel-devel
-cp -a --parents arch/x86/entry/syscalls/syscall_32.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/entry/syscalls/syscall_64.tbl %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_32.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_64.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs_common.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/tools/relocs.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/purgatory.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/stack.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/setup-x86_64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/purgatory/entry64.S %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.h %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/string.c %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents arch/x86/boot/ctype.h %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents scripts/syscalltbl.sh %{buildroot}/lib/modules/%{kverstr}/build/
-cp -a --parents scripts/syscallhdr.sh %{buildroot}/lib/modules/%{kverstr}/build/
-
-cp -a --parents tools/arch/x86/include/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/include/uapi/asm %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/lib %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/lib/ %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/arch/x86/tools/gen-insn-attr-x86.awk %{buildroot}/lib/modules/%{kverstr}/build
-cp -a --parents tools/objtool/arch/x86/ %{buildroot}/lib/modules/%{kverstr}/build
-
-%endif
-# Clean up intermediate tools files
-find %{buildroot}/lib/modules/%{kverstr}/build/tools \( -iname "*.o" -o -iname "*.cmd" \) -exec rm -f {} +
-
-# Make sure the Makefile, version.h, and auto.conf have a matching
-# timestamp so that external modules can be built
-touch -r %{buildroot}/lib/modules/%{kverstr}/build/Makefile \
-%{buildroot}/lib/modules/%{kverstr}/build/include/generated/uapi/linux/version.h \
-%{buildroot}/lib/modules/%{kverstr}/build/include/config/auto.conf
-
-find %{buildroot}/lib/modules/%{kverstr} -name "*.ko" -type f >modnames
-
-# mark modules executable so that strip-to-file can strip them
-xargs --no-run-if-empty chmod u+x < modnames
-
-# Generate a list of modules for block and networking.
-
-grep -F /drivers/ modnames | xargs --no-run-if-empty nm -upA |
-sed -n 's,^.*/\([^/]*\.ko\):  *U \(.*\)$,\1 \2,p' > drivers.undef
-
-collect_modules_list()
-{
-  sed -r -n -e "s/^([^ ]+) \\.?($2)\$/\\1/p" drivers.undef |
-LC_ALL=C sort -u > %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  if [ ! -z "$3" ]; then
-sed -r -e "/^($3)\$/d" -i %{buildroot}/lib/modules/%{kverstr}/modules.$1
-  fi
-}
-
-collect_modules_list networking \
-  'register_netdev|ieee80211_register_hw|usbnet_probe|phy_driver_register|rt(l_|2x00)(pci|usb)_probe|register_netdevice'
-collect_modules_list block \
-  'ata_scsi_ioctl|scsi_add_host|scsi_add_host_with_dma|blk_alloc_queue|blk_init_queue|register_mtd_blktrans|scsi_esp_register|scsi_register_device_handler|blk_queue_physical_block_size' 'pktcdvd.ko|dm-mod.ko'
-collect_modules_list drm \
-  'drm_open|drm_init'
-collect_modules_list modesetting \
-  'drm_crtc_init'
-
-# detect missing or incorrect license tags
-( find %{buildroot}/lib/modules/%{kverstr} -name '*.ko' | xargs /sbin/modinfo -l | \
-grep -E -v 'GPL( v2)?$|Dual BSD/GPL$|Dual MPL/GPL$|GPL and additional rights$' ) && exit 1
-
-remove_depmod_files()
-{
-# remove files that will be auto generated by depmod at rpm -i time
-pushd %{buildroot}/lib/modules/%{kverstr}/
-rm -f modules.{alias,alias.bin,builtin.alias.bin,builtin.bin} \
-  modules.{dep,dep.bin,devname,softdep,symbols,symbols.bin}
-popd
-}
-
-remove_depmod_files
-
-mkdir -p %{buildroot}%{_prefix}/src/kernels
-mv %{buildroot}/lib/modules/%{kverstr}/build %{buildroot}%{_prefix}/src/kernels/%{kverstr}
-
-# This is going to create a broken link during the build, but we don't use
-# it after this point.  We need the link to actually point to something
-# when kernel-devel is installed, and a relative link doesn't work across
-# the F17 UsrMove feature.
-ln -sf %{_prefix}/src/kernels/%{kverstr} %{buildroot}/lib/modules/%{kverstr}/build
-
-find %{buildroot}%{_prefix}/src/kernels -name ".*.cmd" -delete
-#
-
-cp -v System.map %{buildroot}/boot/System.map-%{kverstr}
-cp -v System.map %{buildroot}/lib/modules/%{kverstr}/System.map
-cp -v .config %{buildroot}/boot/config-%{kverstr}
-cp -v .config %{buildroot}/lib/modules/%{kverstr}/config
-
-(cd "%{buildroot}/boot/" && sha512hmac "vmlinuz-%{kverstr}" > ".vmlinuz-%{kverstr}.hmac")
-
-cp -v  %{buildroot}/boot/vmlinuz-%{kverstr} %{buildroot}/lib/modules/%{kverstr}/vmlinuz
-(cd "%{buildroot}/lib/modules/%{kverstr}" && sha512hmac vmlinuz > .vmlinuz.hmac)
-
-# create dummy initramfs image to inflate the disk space requirement for the initramfs. 48M seems to be the right size nowadays with more and more hardware requiring initramfs-located firmware to work properly (for reference, Fedora has it set to 20M)
-dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{kverstr}.img bs=1M count=48
-
-%clean
-rm -rf %{buildroot}
+%description core
+    The kernel package contains the Linux kernel (vmlinuz), the core of any
+    Linux operating system.  The kernel handles the basic functions
+    of the operating system: memory allocation, process allocation, device
+    input and output, etc.
 
 %post core
-if [ `uname -i` == "x86_64" -o `uname -i` == "i386" ] &&
-   [ -f /etc/sysconfig/kernel ]; then
-  /bin/sed -r -i -e 's/^DEFAULTKERNEL=kernel-smp$/DEFAULTKERNEL=kernel/' /etc/sysconfig/kernel || exit $?
-fi
-if [ -x /bin/kernel-install ] && [ -d /boot ]; then
-/bin/kernel-install add %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-fi
+    mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+    touch %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
 
 %posttrans core
-if [ ! -z $(rpm -qa | grep grubby) ]; then
-  grubby --set-default="/boot/vmlinuz-%{kverstr}"
-fi
+    rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
+    /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
+    if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
+        cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+        if command -v restorecon &>/dev/null; then
+            restorecon "/boot/symvers-%{_kver}.zst"
+        fi
+    fi
 
 %preun core
-/bin/kernel-install remove %{kverstr} /lib/modules/%{kverstr}/vmlinuz || exit $?
-if [ -x /usr/sbin/weak-modules ]
-then
-/usr/sbin/weak-modules --remove-kernel %{kverstr} || exit $?
-fi
-
-%post devel
-if [ -f /etc/sysconfig/kernel ]
-then
-. /etc/sysconfig/kernel || exit $?
-fi
-if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]
-then
-(cd /usr/src/kernels/%{kverstr} &&
- /usr/bin/find . -type f | while read f; do
-   hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f 2>&1 >/dev/null
- done)
-fi
-
-%post modules
-/sbin/depmod -a %{kverstr}
-
-%if %{_nv_build}
-%posttrans nvidia-open
-/sbin/depmod -a %{kverstr}
-%endif
+    /bin/kernel-install remove %{_kver} || exit $?
+    if [ -x /usr/sbin/weak-modules ]; then
+        /usr/sbin/weak-modules --remove-kernel %{_kver} || exit $?
+    fi
 
 %files core
-%ghost %attr(0600, root, root) /boot/vmlinuz-%{kverstr}
-%ghost %attr(0600, root, root) /boot/System.map-%{kverstr}
-%ghost %attr(0600, root, root) /boot/initramfs-%{kverstr}.img
-%ghost %attr(0600, root, root) /boot/symvers-%{kverstr}.gz
-%ghost %attr(0644, root, root) /boot/config-%{kverstr}
-/boot/.vmlinuz-%{kverstr}.hmac
-%dir /lib/modules/%{kverstr}/
-/lib/modules/%{kverstr}/.vmlinuz.hmac
-/lib/modules/%{kverstr}/config
-/lib/modules/%{kverstr}/vmlinuz
-/lib/modules/%{kverstr}/System.map
-/lib/modules/%{kverstr}/symvers.gz
+    %dir %{_kernel_dir}
+    %{_kernel_dir}/vmlinuz
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
+    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/config
+    %{_kernel_dir}/System.map
+
+%package modules
+Summary:        Kernel modules package for %{name}.
+Provides:       kernel-modules-uname-r = %{_kver}
+Provides:       kernel-modules-core-uname-r = %{_kver}
+Provides:       installonlypkg(kernel-module)
+Requires:       kernel-uname-r = %{_kver}
+
+%description modules
+    This package provides kernel modules for the %{name}-core kernel package.
+
+%post modules
+    /sbin/depmod -a %{_kver}
+    if [ ! -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver} ]; then
+        mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
+        touch %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+    fi
+
+%posttrans modules
+    if [ -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver} ]; then
+        rm -f %{_localstatedir}/lib/rpm-state/%{name}/need_to_run_dracut_%{_kver}
+        echo "Running: dracut -f --kver %{_kver}"
+        dracut -f --kver "%{_kver}" || exit $?
+    fi
+
+%postun modules
+    /sbin/depmod -a %{_kver}
 
 %files modules
-/lib/modules/%{kverstr}/
-%exclude /lib/modules/%{kverstr}/.vmlinuz.hmac
-%exclude /lib/modules/%{kverstr}/config
-%exclude /lib/modules/%{kverstr}/vmlinuz
-%exclude /lib/modules/%{kverstr}/System.map
-%exclude /lib/modules/%{kverstr}/symvers.gz
-%exclude /lib/modules/%{kverstr}/build
-%exclude /lib/modules/%{kverstr}/source
-%if %{_nv_build}
-%exclude /lib/modules/%{kverstr}/nvidia
+    %{_kernel_dir}/modules.order
+    %{_kernel_dir}/build
+    %{_kernel_dir}/source
+    %{_kernel_dir}/kernel
 
-%files nvidia-open
-/lib/modules/%{kverstr}/nvidia
-/usr/share/licenses/nvidia-open/COPYING
-%endif
+%package devel
+Summary:        Development package for building kernel modules to match %{name}
+Provides:       kernel-devel-uname-r = %{_kver}
+Provides:       installonlypkg(kernel)
+AutoReqProv:    no
+Requires(pre):  findutils
+Requires:       findutils
+Requires:       perl-interpreter
+Requires:       openssl-devel
+Requires:       elfutils-libelf-devel
+Requires:       bison
+Requires:       flex
+Requires:       make
+Requires:       gcc
 
-%files headers
-%defattr (-, root, root)
-/usr/include/*
+%description devel
+    This package provides kernel headers and makefiles sufficient to build modules against %{name}.
+
+%post devel
+    if [ -f /etc/sysconfig/kernel ]; then
+        . /etc/sysconfig/kernel || exit $?
+    fi
+    if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]; then
+        (cd /usr/src/kernels/%{_kver} &&
+        /usr/bin/find . -type f | while read f; do
+            hardlink -c /usr/src/kernels/*%{?dist}.*/$f $f > /dev/null
+        done;
+        )
+    fi
 
 %files devel
-%defattr (-, root, root)
-/usr/src/kernels/%{kverstr}
-/lib/modules/%{kverstr}/build
-/lib/modules/%{kverstr}/source
-
-%files devel-matched
+    %{_devel_dir}
 
 %files
+
+

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -52,7 +52,7 @@
 # Define variables for directory paths
 # to be used during packaging
 %define _kernel_dir /lib/modules/%{_kver}
-%define _devel_dir /usr/src/kernels/%{_kver}
+%define _devel_dir %{_usrsrc}/kernels/%{_kver}
 
 %define _patch_src https://raw.githubusercontent.com/CachyOS/kernel-patches/master/%{_basekver}
 
@@ -67,7 +67,7 @@
 Name:           kernel-cachyos%{?_is_lto:-lto}
 Summary:        Linux BORE %{?_is_lto:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos8%{?_is_lto:.lto}%{?dist}
+Release:        cachyos9%{?_is_lto:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -314,7 +314,7 @@ Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-n
         cd %{_builddir}/%{_nv_pkg}
         install -Dt %{buildroot}%{_kernel_dir}/nvidia -m644 kernel-open/*.ko
         find %{buildroot}%{_kernel_dir}/nvidia -name '*.ko' -exec zstd --rm -19 {} +
-        install -Dt %{buildroot}/usr/share/licenses/%{name}-nvidia-open -m644 COPYING
+        install -Dt %{buildroot}/%{_defaultlicensedir}/%{name}-nvidia-open -m644 COPYING
     %endif
 
 %package core
@@ -463,7 +463,7 @@ Recommends:     xorg-x11-drv-nvidia >= %{_nv_ver}
     /sbin/depmod -a %{_kver}
 
 %files nvidia-open
-    %license /usr/share/licenses/%{name}-nvidia-open/COPYING
+    %license %{_defaultlicensedir}/%{name}-nvidia-open/COPYING
     %{_kernel_dir}/nvidia
 %endif
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos1%{?_lto_args:.lto}%{?dist}
+Release:        cachyos2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -371,8 +371,6 @@ Recommends:     linux-firmware
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
-    %{_kernel_dir}/modules.builtin
-    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/symvers.zst
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
@@ -405,10 +403,9 @@ Requires:       kernel-uname-r = %{_kver}
         fi
     fi
 
-%postun modules
-    /sbin/depmod -a %{_kver}
-
 %files modules
+    %{_kernel_dir}/modules.builtin
+    %{_kernel_dir}/modules.builtin.modinfo
     %{_kernel_dir}/modules.order
     %{_kernel_dir}/build
     %{_kernel_dir}/source

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -1,11 +1,12 @@
 # Maintainer: Eric Naim <dnaim@cachyos.org>
 
 # Fedora bits
-%define __spec_install_post /usr/lib/rpm/brp-compress || :
+%define __spec_install_post %{__os_install_post}
 %define _default_patch_fuzz 2
 %define _disable_source_fetch 0
 %define debug_package %{nil}
 %define make_build make %{?_build_args} %{?_smp_mflags}
+%undefine __brp_mangle_shebangs
 %undefine _auto_set_build_flags
 %undefine _include_frame_pointers
 
@@ -80,6 +81,7 @@ BuildRequires:  perl-generators
 BuildRequires:  perl-interpreter
 BuildRequires:  python3-devel
 BuildRequires:  python3-pyyaml
+BuildRequires:  python-srpm-macros
 BuildRequires:  redhat-rpm-config
 BuildRequires:  tar
 BuildRequires:  xz

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -53,7 +53,7 @@ Name:           kernel-cachyos%{?_is_lto:-lto}
 Summary:        Linux BORE %{?_is_lto:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
 Release:        cachyos8%{?_is_lto:.lto}%{?dist}
-License:        GPL-2.0-Only
+License:        GPL-2.0-only
 URL:            https://cachyos.org
 
 Requires:       kernel-core-uname-r = %{_kver}
@@ -328,6 +328,7 @@ Requires:       kmod
 
 %files core
     %dir %{_kernel_dir}
+    %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -46,7 +46,7 @@ BuildRequires:  make
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
 BuildRequires:  perl-Carp
-BuildRequires:  perl-devel,
+BuildRequires:  perl-devel
 BuildRequires:  perl-generators
 BuildRequires:  perl-interpreter
 BuildRequires:  python3-devel
@@ -65,7 +65,6 @@ Patch1:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/
 
 %description
     The meta package for %{name}.
-
 
 %prep
     %setup -q -n linux-%{version}
@@ -189,6 +188,14 @@ Patch1:         https://raw.githubusercontent.com/CachyOS/kernel-patches/master/
     ln -s %{_devel_dir} %{buildroot}%{_kernel_dir}/build
     ln -s %{_kernel_dir}/build %{buildroot}%{_kernel_dir}/source
 
+    # Create stub initramfs to inflate disk space requirements.
+    # This should hopefully prevent some initramfs failures due to
+    # insufficient space in /boot (#bz #530778)
+    # 90 seems to be a safe value nowadays. It is slightly inflated than the
+    # measured average to also account for installed vmlinuz in /boot
+    install -dm755 %{buildroot}/boot
+    dd if=/dev/zero of=%{buildroot}/boot/initramfs-%{_kver}.img bs=1M count=90
+
 %package core
 Summary:        Linux BORE Cachy Sauce Kernel by CachyOS with other patches and improvements
 Provides:       kernel-core-uname-r = %{_kver}
@@ -226,6 +233,7 @@ Requires:       kmod
 
 %files core
     %dir %{_kernel_dir}
+    %ghost /boot/initramfs-%{_kver}.img
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -5,7 +5,7 @@
 %define _default_patch_fuzz 2
 %define _disable_source_fetch 0
 %define debug_package %{nil}
-%define make_build make %{?_build_args} %{?_smp_mflags}
+%define make_build make %{?_lto_args} %{?_smp_mflags}
 %undefine __brp_mangle_shebangs
 %undefine _auto_set_build_flags
 %undefine _include_frame_pointers
@@ -58,16 +58,15 @@
 
 %if %{_build_lto}
     # Define build environment variables to build the kernel with clang
-    %define _build_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
-    %define _is_lto 1
+    %define _lto_args CC=clang CXX=clang++ LD=ld.lld LLVM=1 LLVM_IAS=1
 %endif
 
 %define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver}
 
-Name:           kernel-cachyos%{?_is_lto:-lto}
-Summary:        Linux BORE %{?_is_lto:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
+Name:           kernel-cachyos%{?_lto_args:-lto}
+Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos9%{?_is_lto:.lto}%{?dist}
+Release:        cachyos9%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 
@@ -139,12 +138,7 @@ Patch13:        %{_patch_src}/misc/nvidia/0005-nvkms-Sanitize-trim-ELD-product-n
     The meta package for %{name}.
 
 %prep
-    %if %{_build_nv}
-        %setup -q -b 10 -n linux-%{_tarkver}
-    %else
-        %setup -q -n linux-%{_tarkver}
-    %endif
-
+    %setup -q %{?SOURCE10:-b 10} -n linux-%{_tarkver}
     %autopatch -p1 -v -M 9
 
     cp %{SOURCE1} .config

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -12,7 +12,7 @@
 
 # Linux Kernel Versions
 %define _basekver 6.12
-%define _stablekver 9
+%define _stablekver 10
 %define _rpmver %{version}-%{release}
 %define _kver %{_rpmver}.%{_arch}
 
@@ -66,7 +66,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos9%{?_lto_args:.lto}%{?dist}
+Release:        cachyos1%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -15,6 +15,12 @@
 %define _rpmver %{version}-%{release}
 %define _kver %{_rpmver}.%{_arch}
 
+%if %{_stablekver} == 0
+    %define _tarkver %{_basekver}
+%else
+    %define _tarkver %{version}
+%endif
+
 # Build a minimal a kernel via modprobed.db
 # file to reduce build times.
 %define _build_minimal 0
@@ -40,7 +46,7 @@
     %define _is_lto 1
 %endif
 
-%define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{version} SYSOUT=%{_builddir}/linux-%{version}
+%define _module_args KERNEL_UNAME=%{_kver} IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=%{_builddir}/linux-%{_tarkver} SYSOUT=%{_builddir}/linux-%{_tarkver}
 
 Name:           kernel-cachyos%{?_is_lto:-lto}
 Summary:        Linux BORE %{?_is_lto:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
@@ -90,8 +96,7 @@ BuildRequires:  gcc-c++
 %endif
 
 # Indexes 0-9 are reserved for the kernel. 10-19 will be reserved for NVIDIA
-Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{version}.tar.xz
-#Source0:       https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%_basekver.tar.xz
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{_tarkver}.tar.xz
 Source1:        https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/config
 
 %if %{_build_minimal}
@@ -124,9 +129,9 @@ Patch13:        https://raw.githubusercontent.com/CachyOS/kernel-patches/master/
 
 %prep
     %if %{_build_nv}
-        %setup -q -b 10 -n linux-%{version}
+        %setup -q -b 10 -n linux-%{_tarkver}
     %else
-        %setup -q -n linux-%{version}
+        %setup -q -n linux-%{_tarkver}
     %endif
 
     %autopatch -p1 -v -M 9


### PR DESCRIPTION
This is an attempt to rewrite the kernel build spec to be much more readable and easier to grasp. Some liberties were taken during this initial rewrite, namely that it only supports x86_64 for now. This *should* be the only architecture that we need to support, because the CachyOS patchset is primarily for x86_64.

Firstly, all parts of the build process have proper identation to make it easier to read. Each declaration of a variable (name, version, builddeps) are also properly spaced such that everything is aligned. Second, building kernel-headers was removed. The reason is because that this part of the kernel doesn't need to be built by us, and it doesn't have to have the same kernel version as the installed system either. This package is mainly used to build toolchains and core libraries. For some context, see the Arch equivalent package linux-api-headers[2]

Moved subpackage declarations down the file to join it with their %post and %files counterparts.

I've used the %autopatch macro instead of calling patch manually. This has the added benefit of keeping the patching stage in one line. Some groundrules need to made here to accomodate this change, namely ALL source and patch indexes from 0-9 are reserved solely for the kernel. When NVIDIA gets added back, it will occupy indexes 10-19. Lastly, the generation of symvers is compressed with zstd instead of xz in upstream Fedora, and instead of gz which was used previously in our spec.

[1] https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/main/PKGBUILD
[2] https://gitlab.archlinux.org/archlinux/packaging/packages/linux-api-headers