### PR TITLE
Advise against using ananicy-cpp together with sched-ext's schedulers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ sudo systemctl enable --now uksmd.service
 ```
 
 #### ananicy-cpp
+
+> [It is advised against running `ananicy-cpp` and a scheduler from the `sched-ext` framework *simultaneously*. Use one but not the other.](https://wiki.cachyos.org/configuration/sched-ext/#disable-ananicy-cpp)
+
 ```bash
 sudo dnf install ananicy-cpp
 sudo systemctl enable --now ananicy-cpp


### PR DESCRIPTION
The CachyOS wiki recommends disabling `ananicy-cpp` to not cause problems when the user also uses a `sched-ext` scheduler[^1].

I've included a word of caution, which is also a hyperlink to footnote 1. 

Also, why doesn't the [COPR repository](https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos/) have the much-needed information that this README has?

[^1]: https://wiki.cachyos.org/configuration/sched-ext/#disable-ananicy-cpp