### PR TITLE
kernel-cachyos: Use xz instead of zstd for symvers

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -73,7 +73,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos1%{?_lto_args:.lto}%{?dist}
+Release:        cachyos2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -216,7 +216,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
+    xz -c9e < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -216,7 +216,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
+    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
@@ -363,10 +363,10 @@ Recommends:     linux-firmware
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
     if [ ! -e /run/ostree-booted ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
-        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
-            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+        if [[ ! -e "/boot/symvers-%{_kver}.xz" ]]; then
+            cp "%{_kernel_dir}/symvers.xz" "/boot/symvers-%{_kver}.xz"
             if command -v restorecon &>/dev/null; then
-                restorecon "/boot/symvers-%{_kver}.zst"
+                restorecon "/boot/symvers-%{_kver}.xz"
             fi
         fi
     fi
@@ -383,7 +383,7 @@ Recommends:     linux-firmware
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo
-    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/symvers.xz
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -211,7 +211,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
+    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
@@ -358,10 +358,10 @@ Recommends:     linux-firmware
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
     if [ ! -e /run/ostree-booted ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
-        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
-            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+        if [[ ! -e "/boot/symvers-%{_kver}.xz" ]]; then
+            cp "%{_kernel_dir}/symvers.xz" "/boot/symvers-%{_kver}.xz"
             if command -v restorecon &>/dev/null; then
-                restorecon "/boot/symvers-%{_kver}.zst"
+                restorecon "/boot/symvers-%{_kver}.xz"
             fi
         fi
     fi
@@ -378,7 +378,7 @@ Recommends:     linux-firmware
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo
-    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/symvers.xz
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -211,7 +211,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
+    xz -c9e < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -73,7 +73,7 @@
 Name:           kernel-cachyos-lts%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachylts1%{?_lto_args:.lto}%{?dist}
+Release:        cachylts2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -211,7 +211,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
+    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
@@ -358,10 +358,10 @@ Recommends:     linux-firmware
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
     if [ ! -e /run/ostree-booted ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
-        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
-            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+        if [[ ! -e "/boot/symvers-%{_kver}.xz" ]]; then
+            cp "%{_kernel_dir}/symvers.xz" "/boot/symvers-%{_kver}.xz"
             if command -v restorecon &>/dev/null; then
-                restorecon "/boot/symvers-%{_kver}.zst"
+                restorecon "/boot/symvers-%{_kver}.xz"
             fi
         fi
     fi
@@ -378,7 +378,7 @@ Recommends:     linux-firmware
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo
-    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/symvers.xz
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -211,7 +211,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
+    xz -c9e < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -73,7 +73,7 @@
 Name:           kernel-cachyos-lts%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachylts1%{?_lto_args:.lto}%{?dist}
+Release:        cachylts2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -221,7 +221,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
+    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
@@ -368,10 +368,10 @@ Recommends:     linux-firmware
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
     if [ ! -e /run/ostree-booted ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
-        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
-            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+        if [[ ! -e "/boot/symvers-%{_kver}.xz" ]]; then
+            cp "%{_kernel_dir}/symvers.xz" "/boot/symvers-%{_kver}.xz"
             if command -v restorecon &>/dev/null; then
-                restorecon "/boot/symvers-%{_kver}.zst"
+                restorecon "/boot/symvers-%{_kver}.xz"
             fi
         fi
     fi
@@ -388,7 +388,7 @@ Recommends:     linux-firmware
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo
-    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/symvers.xz
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -73,7 +73,7 @@
 Name:           kernel-cachyos-rt%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyrt1%{?_lto_args:.lto}%{?dist}
+Release:        cachyrt2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -221,7 +221,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
+    xz -c9e < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -73,7 +73,7 @@
 Name:           kernel-cachyos%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos1%{?_lto_args:.lto}%{?dist}
+Release:        cachyos2%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -216,7 +216,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
+    xz -c9e < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -216,7 +216,7 @@ cd ..
 %install
     echo "Installing the kernel image..."
     install -Dm644 "$(%make_build -s image_name)" "%{buildroot}%{_kernel_dir}/vmlinuz"
-    zstdmt -19 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.zst
+    xz -c9 < Module.symvers > %{buildroot}%{_kernel_dir}/symvers.xz
 
     echo "Installing kernel modules..."
     ZSTD_CLEVEL=19 %make_build INSTALL_MOD_PATH="%{buildroot}" INSTALL_MOD_STRIP=1 DEPMOD=/doesnt/exist modules_install
@@ -363,10 +363,10 @@ Recommends:     linux-firmware
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
     if [ ! -e /run/ostree-booted ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
-        if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
-            cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"
+        if [[ ! -e "/boot/symvers-%{_kver}.xz" ]]; then
+            cp "%{_kernel_dir}/symvers.xz" "/boot/symvers-%{_kver}.xz"
             if command -v restorecon &>/dev/null; then
-                restorecon "/boot/symvers-%{_kver}.zst"
+                restorecon "/boot/symvers-%{_kver}.xz"
             fi
         fi
     fi
@@ -383,7 +383,7 @@ Recommends:     linux-firmware
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo
-    %{_kernel_dir}/symvers.zst
+    %{_kernel_dir}/symvers.xz
     %{_kernel_dir}/config
     %{_kernel_dir}/System.map
 


### PR DESCRIPTION
`/usr/sbin/weak-modules` doesn't support zstd-compressed symvers yet, leaving orphaned files in /boot