### PR TITLE
kernel-cachyos: %ghost files changes

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -380,6 +380,7 @@ Recommends:     linux-firmware
 %files core
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
+    %ghost /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -379,8 +379,8 @@ Recommends:     linux-firmware
 
 %files core
     %license COPYING
-    %ghost /boot/initramfs-%{_kver}.img
-    %ghost /boot/symvers-%{_kver}.zst
+    %ghost %attr(0600, root, root) /boot/initramfs-%{_kver}.img
+    %ghost %attr(0644, root, root) /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -375,6 +375,7 @@ Recommends:     linux-firmware
 %files core
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
+    %ghost /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -374,8 +374,8 @@ Recommends:     linux-firmware
 
 %files core
     %license COPYING
-    %ghost /boot/initramfs-%{_kver}.img
-    %ghost /boot/symvers-%{_kver}.zst
+    %ghost %attr(0600, root, root) /boot/initramfs-%{_kver}.img
+    %ghost %attr(0644, root, root) /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -375,6 +375,7 @@ Recommends:     linux-firmware
 %files core
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
+    %ghost /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -374,8 +374,8 @@ Recommends:     linux-firmware
 
 %files core
     %license COPYING
-    %ghost /boot/initramfs-%{_kver}.img
-    %ghost /boot/symvers-%{_kver}.zst
+    %ghost %attr(0600, root, root) /boot/initramfs-%{_kver}.img
+    %ghost %attr(0644, root, root) /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -385,6 +385,7 @@ Recommends:     linux-firmware
 %files core
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
+    %ghost /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -384,8 +384,8 @@ Recommends:     linux-firmware
 
 %files core
     %license COPYING
-    %ghost /boot/initramfs-%{_kver}.img
-    %ghost /boot/symvers-%{_kver}.zst
+    %ghost %attr(0600, root, root) /boot/initramfs-%{_kver}.img
+    %ghost %attr(0644, root, root) /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -380,6 +380,7 @@ Recommends:     linux-firmware
 %files core
     %license COPYING
     %ghost /boot/initramfs-%{_kver}.img
+    %ghost /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -379,8 +379,8 @@ Recommends:     linux-firmware
 
 %files core
     %license COPYING
-    %ghost /boot/initramfs-%{_kver}.img
-    %ghost /boot/symvers-%{_kver}.zst
+    %ghost %attr(0600, root, root) /boot/initramfs-%{_kver}.img
+    %ghost %attr(0644, root, root) /boot/symvers-%{_kver}.zst
     %{_kernel_dir}/vmlinuz
     %{_kernel_dir}/modules.builtin
     %{_kernel_dir}/modules.builtin.modinfo


### PR DESCRIPTION
### Changes:
 
 - **Set explicit attributes for files marked with %ghost:**
This prevents tripping the package verification system (invoked with rpm -V \<package name\>) which marks them as modified due to mismatching permissions between the rpm database and the filesystem.

- **Mark /boot/symvers-%{_kver}.zst as %ghost:**
This makes the core package own the path, removing the symvers file together with the kernel package preventing leaving behind orphaned files.