### PR TITLE
scx: add conflicts and bump versions

### DIFF
--- a/sources/scx-scheds-git/scx-scheds-git.spec
+++ b/sources/scx-scheds-git/scx-scheds-git.spec
@@ -39,7 +39,7 @@ Conflicts: scx_rustland
 Conflicts: scx_rusty
 Conflicts: scx_c_schedulers
 Conflicts: rust-scx_utils-devel
-Provides: scx-scheds
+Provides: scx-scheds = %{version}
 Provides: scx_layered
 Provides: scx_rustland
 Provides: scx_rusty

--- a/sources/scx-scheds-git/scx-scheds-git.spec
+++ b/sources/scx-scheds-git/scx-scheds-git.spec
@@ -39,6 +39,12 @@ Conflicts: scx_rustland
 Conflicts: scx_rusty
 Conflicts: scx_c_schedulers
 Conflicts: rust-scx_utils-devel
+Provides: scx-scheds
+Provides: scx_layered
+Provides: scx_rustland
+Provides: scx_rusty
+Provides: scx_c_schedulers
+Provides: rust-scx_utils-devel
 
 %description
 sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. This repository contains various scheduler implementations and support utilities.

--- a/sources/scx-scheds-git/scx-scheds-git.spec
+++ b/sources/scx-scheds-git/scx-scheds-git.spec
@@ -1,6 +1,6 @@
 %global _default_patch_fuzz 2
-%global commitdate 20250205
-%global commit fef8e5ebbbef3b4eb8acb3a71dcc24f99bf06554
+%global commitdate 20250224
+%global commit 5af7fdddb1a712f66119327900653448b5b0046f
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %define _disable_source_fetch 0
@@ -34,6 +34,11 @@ Requires:  elfutils-libelf
 Requires:  zlib
 Requires:  jq
 Conflicts: scx-scheds
+Conflicts: scx_layered
+Conflicts: scx_rustland
+Conflicts: scx_rusty
+Conflicts: scx_c_schedulers
+Conflicts: rust-scx_utils-devel
 
 %description
 sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. This repository contains various scheduler implementations and support utilities.

--- a/sources/scx-scheds/scx-scheds.spec
+++ b/sources/scx-scheds/scx-scheds.spec
@@ -34,7 +34,6 @@ Conflicts: scx_rustland
 Conflicts: scx_rusty
 Conflicts: scx_c_schedulers
 Conflicts: rust-scx_utils-devel
-Provides: scx-scheds
 Provides: scx_layered
 Provides: scx_rustland
 Provides: scx_rusty

--- a/sources/scx-scheds/scx-scheds.spec
+++ b/sources/scx-scheds/scx-scheds.spec
@@ -2,7 +2,7 @@
 
 Name:           scx-scheds
 Version:        1.0.9
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Sched_ext Schedulers and Tools
 
 License:        GPL=2.0
@@ -29,6 +29,11 @@ Requires:  elfutils-libelf
 Requires:  zlib
 Requires:  jq
 Conflicts: scx-scheds-git
+Conflicts: scx_layered
+Conflicts: scx_rustland
+Conflicts: scx_rusty
+Conflicts: scx_c_schedulers
+Conflicts: rust-scx_utils-devel
 
 %description
 sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. This repository contains various scheduler implementations and support utilities.

--- a/sources/scx-scheds/scx-scheds.spec
+++ b/sources/scx-scheds/scx-scheds.spec
@@ -34,6 +34,12 @@ Conflicts: scx_rustland
 Conflicts: scx_rusty
 Conflicts: scx_c_schedulers
 Conflicts: rust-scx_utils-devel
+Provides: scx-scheds
+Provides: scx_layered
+Provides: scx_rustland
+Provides: scx_rusty
+Provides: scx_c_schedulers
+Provides: rust-scx_utils-devel
 
 %description
 sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. This repository contains various scheduler implementations and support utilities.


### PR DESCRIPTION
There are several schedulers in the Fedora repository, but not all of them (lavd, bpfland, flash, p2dq are missing) [1] and setting conflicts with packages from the repo will help avoid potential problems with installing our package from COPR. 

1. https://packages.fedoraproject.org/search?query=scx