### PR TITLE
Add instructions for making the CachyOS kernel the default across updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository is maintained by [@andersrh](https://github.com/andersrh) and [@
 - [Kernels](#-kernels)
   - [Features](#-features)
   - [Installation Instructions](#%EF%B8%8F-installation-instructions)
+    - [Default Kernel](#default-kernel)
 - [Addons](#-addons)
   - [CachyOS-Settings](#cachyos-settings)
   - [scx-scheds](#scx-scheds)
@@ -85,6 +86,30 @@ sudo wget https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos/re
 sudo rpm-ostree override remove kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra --install kernel-cachyos
 sudo systemctl reboot
 ```
+
+### Default Kernel
+By default Fedora will use the kernel that was most recently updated by `dnf` which will lead to inconsistent behaviour if you have multiple kernels installed, but we can tell Fedora to always boot with the latest CachyOS kernel by running a script after kernel updates.
+
+Create a file in `/etc/kernel/postinst.d`:
+```bash
+sudo nano /etc/kernel/postinst.d/99-default
+```
+
+Enter the following content that will set the latest CachyOS kernel as the default kernel:
+```bash
+#!/bin/sh
+
+set -e
+
+grubby --set-default=/boot/$(ls /boot | grep vmlinuz.*cachy | sort -V | tail -1)
+```
+
+Make `root` the owner and make the script executable:
+```bash
+sudo chown root:root /etc/kernel/postinst.d/99-default ; sudo chmod u+rx /etc/kernel/postinst.d/99-default
+```
+
+The next time any installed kernel (e.g. the official Fedora kernel) gets an update, the system will change default kernel back to the latest CachyOS kernel. This way you can keep the official kernel as a backup in case an update goes wrong and you need to temporarily switch to the official kernel.
 
 # 🧩 Addons
 We provide a few addons that supplement the kernel packages and system.


### PR DESCRIPTION
This script has been working very well for me over the past few months, and gives me peace of mind as I don't have to uninstall the official Fedora kernel and can easily switch back if an update goes wrong.

I wonder if maybe the script should be bundled with the kernels? `sbctl` bundles similar scripts to sign kernel updates.

If you only follow the current installation instructions the machine is going to switch back and forth between the CachyOS kernel and the official Fedora kernel, e.g. `6.15.8-cachyos -> 6.15.7-200 -> 6.15.8-200 -> 6.15.9-cachyos ...` and with the kernel post-install hook it's simply `6.15.7-cachyos -> 6.15.8-cachyos -> 6.15.9-cachyos`.