### PR TITLE
Reapply "Use dynamicaly linked bpftool and libbpf for scx-scheds"

### DIFF
--- a/sources/scx-scheds/scx-scheds.spec
+++ b/sources/scx-scheds/scx-scheds.spec
@@ -27,11 +27,14 @@ BuildRequires:  systemd
 BuildRequires:  bpftool
 BuildRequires:  protobuf-compiler
 BuildRequires:  libseccomp-devel
+BuildRequires:  libbpf-devel
 Requires:  elfutils-libelf
 Requires:  libseccomp
 Requires:  protobuf
 Requires:  zlib
 Requires:  jq
+Requires:  libbpf
+Requires:  bpftool
 Conflicts: scx-scheds-git
 Conflicts: scx_layered
 Conflicts: scx_rustland
@@ -56,7 +59,9 @@ sched_ext is a Linux kernel feature which enables implementing kernel thread sch
 %meson \
  -Dsystemd=enabled \
  -Dopenrc=disabled \
- -Dlibalpm=disabled
+ -Dlibalpm=disabled \
+ -Dlibbpf_a=disabled \
+ -Dbpftool=disabled
 %meson_build
 
 


### PR DESCRIPTION
scx-scheds doesn't build on Fedora 41 and EPEL 10.
It gives the following error:
```
/usr/bin/ld: cannot find /builddir/build/BUILD/scx-scheds-1.0.14-build/scx-1.0.14/redhat-linux-build/libbpf/src/libbpf.a: No such file or directory
collect2: error: ld returned 1 exit status
```
Though scx-scheds-git has no issues.
I'm proposing that we link libbpf and bpftool dynamically against the system version. When doing this there are no issues. Issues with static linking isn't new, I remember having issues with this before for bpftool, so had to include it as a dependency, which means the system version might be used anyways.

Let me know if you think we shall do this as a temp or permanent solution.
