### PR TITLE
Updated the section on how to install the "cachyos-settings"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Now you can install the addon packages.
 
 ### CachyOS-Settings
 ```bash
-sudo dnf install cachyos-settings --allowerasing
+sudo dnf swap zram-generator-defaults cachyos-settings
 sudo dracut -f
 ```
 


### PR DESCRIPTION
Running just "sudo dnf install cachyos-settings" won't work due to a conflict between the "zram-generator-defaults" package provided by the COPR and the one already installed from Fedora's repositories. Adding the "--allowerasing" flag allows DNF to automatically remove the conflicting pre-installed package.