### PR TITLE
6.18: Fix compilation error and upgrade Nvidia OpenGPU version on Fedora 43

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -137,6 +137,9 @@ Patch2:         %{_patch_src}/misc/dkms-clang.patch
 
 %if %{_build_nv}
 Patch10:        %{_patch_src}/misc/nvidia/0001-Enable-atomic-kernel-modesetting-by-default.patch
+Patch11:        %{_patch_src}/misc/nvidia/0002-Add-IBT-support.patch
+Patch12:        %{_patch_src}/misc/nvidia/0003-nvidia-uvm-Remove-unused-get_devmap_page-parameter.patch
+Patch13:        %{_patch_src}/misc/nvidia/0004-nvkms-Limit-default-maximum-TMDS-character-rate-to-3.patch
 %endif
 
 %description
@@ -199,7 +202,9 @@ Patch10:        %{_patch_src}/misc/nvidia/0001-Enable-atomic-kernel-modesetting-
 cd %{_builddir}/%{_nv_pkg}/kernel-open
 %patch -P 10 -p1
 cd ..
-%autopatch -p1 -v -m 11 -M 19
+%patch -P 11 -p1
+%patch -P 12 -p1
+%patch -P 13 -p1
 %endif
 
 %build


### PR DESCRIPTION
1: I meet compiling error while compiling Nvidia OpenGPU driver 580.105.08, and I also found Nvidia OpenGPU version has upgraded to 580.105.08, so open this PR to fix the problem.
2: I found if enable Clang ThinLTO, which might use "CONFIG_LTO_CLANG_THIN" not "LTO_CLANG_THIN"
3: I also found CachyOS kernel team has created a option called "CONFIG_LTO_CLANG_THIN_DIST", so I enable it on the second commit
4: I can make sure that these changes could work because I have succeeded on my COPR REPO with CachyOS v2,v3,v4 kernel even with Clang Full-LTO enabled: https://copr.fedorainfracloud.org/coprs/mozixun and my full modify repo is at: https://github.com/LFRon/Fedora-CachyOS-Patch-Kernel
Could developer merge them with modify so Fedora users could enjoy the CachyOS kernel with best performance and experience? Thanks🌹