### PR TITLE
scx-scheds-git: bump version and tag

### DIFF
--- a/sources/scx-scheds-git/scx-scheds-git.spec
+++ b/sources/scx-scheds-git/scx-scheds-git.spec
@@ -1,6 +1,6 @@
 %global _default_patch_fuzz 2
-%global commitdate 20251220
-%global commit c12b22facccd9ce1b4ff1223c23be15a8b48ad12
+%global commitdate 20251229
+%global commit d5781b161b214281db19feb953e6c2d32dae25a7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %define _disable_source_fetch 0


### PR DESCRIPTION
Bumps the version for a few lavd fixes, already tested from a personal Copr. Had to resubmit because I forgot to rename the branch before the PR.