### PR TITLE
Rename sbctl-batch-sign to avoid package conflict

### DIFF
--- a/sources/cachyos-settings/cachyos-settings.spec
+++ b/sources/cachyos-settings/cachyos-settings.spec
@@ -27,14 +27,22 @@ Obsoletes:      bore-sysctl
     install -d %{buildroot}/%{_prefix}/lib
     cp %{_builddir}/CachyOS-Settings-%{version}/usr/{bin,lib} %{buildroot}/%{_prefix} -r
     mv %{buildroot}/%{_prefix}/lib/modprobe.d/nvidia.conf %{buildroot}/%{_prefix}/lib/modprobe.d/nvidia_cachyos.conf
+    
+    # Rename conflicting sbctl-batch-sign to avoid conflict with Fedora sbctl package
+    if [ -f %{buildroot}/%{_bindir}/sbctl-batch-sign ]; then
+        mv %{buildroot}/%{_bindir}/sbctl-batch-sign %{buildroot}/%{_bindir}/sbctl-batch-sign-cachyos
+    fi
+    
     chmod +x %{buildroot}/%{_bindir}/*
 
 %files
+    %{_bindir}/sbctl-batch-sign-cachyos
     %{_bindir}/*
     %{_prefix}/lib/*
 
 %changelog
 %autochangelog
+
 
 
 

--- a/sources/cachyos-settings/cachyos-settings.spec
+++ b/sources/cachyos-settings/cachyos-settings.spec
@@ -27,12 +27,13 @@ Obsoletes:      bore-sysctl
     install -d %{buildroot}/%{_prefix}/lib
     cp %{_builddir}/CachyOS-Settings-%{version}/usr/{bin,lib} %{buildroot}/%{_prefix} -r
     mv %{buildroot}/%{_prefix}/lib/modprobe.d/nvidia.conf %{buildroot}/%{_prefix}/lib/modprobe.d/nvidia_cachyos.conf
-    
+%if 0%{?rhel}
+    rm -f %{buildroot}/%{_prefix}/lib/NetworkManager/conf.d/dns.conf
+%endif
     # Rename conflicting sbctl-batch-sign to avoid conflict with Fedora sbctl package
     if [ -f %{buildroot}/%{_bindir}/sbctl-batch-sign ]; then
         mv %{buildroot}/%{_bindir}/sbctl-batch-sign %{buildroot}/%{_bindir}/sbctl-batch-sign-cachyos
     fi
-    
     chmod +x %{buildroot}/%{_bindir}/*
 
 %files


### PR DESCRIPTION
Renamed sbctl-batch-sign to sbctl-batch-sign-cachyos to avoid conflict with sbctl package. Fixes #51 without requiring a switch from sbctl to mokutil. I just personally symlink ```/usr/bin/sbctl-batch-sign-cachyos``` to ```/usr/local/bin/sbctl-batch-sign``` after doing this.