### PR TITLE
Revise default kernel setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,25 +92,20 @@ sudo systemctl reboot
 ```
 
 ### Default Kernel
-By default Fedora will use the kernel that was most recently updated by `dnf` which will lead to inconsistent behaviour if you have multiple kernels installed, but we can tell Fedora to always boot with the latest CachyOS kernel by running a script after kernel updates.
+By default Fedora will use the kernel that was most recently updated by `dnf` which will lead to inconsistent behaviour if you have multiple kernels installed, but we can tell Fedora to always boot with the latest CachyOS kernel by running a command after all kernel updates.
 
-Create a file in `/etc/kernel/postinst.d`:
-```bash
-sudo nano /etc/kernel/postinst.d/99-default
-```
+```sh
+# Install the DNF5 actions plugin
+sudo dnf install libdnf5-plugin-actions
 
-Enter the following content that will set the latest CachyOS kernel as the default kernel:
-```bash
-#!/bin/sh
+# Create the actions directory
+sudo mkdir -p /etc/dnf/libdnf5-plugins/actions.d
 
-set -e
-
-grubby --set-default=/boot/$(ls /boot | grep vmlinuz.*cachy | sort -V | tail -1)
-```
-
-Make `root` the owner and make the script executable:
-```bash
-sudo chown root:root /etc/kernel/postinst.d/99-default ; sudo chmod u+rx /etc/kernel/postinst.d/99-default
+# Create the post_transaction action for kernel* packages
+sudo tee /etc/dnf/libdnf5-plugins/actions.d/cachy-default.actions << 'EOF'
+# After installing any kernel* package, set the latest CachyOS kernel as the default boot entry
+post_transaction:kernel*:in::/usr/bin/sh -c /usr/bin/grubby\ --set-default=/boot/$(ls\ /boot\ |\ grep\ vmlinuz.*cachy\ |\ sort\ -V\ |\ tail\ -1)
+EOF
 ```
 
 The next time any installed kernel (e.g. the official Fedora kernel) gets an update, the system will change default kernel back to the latest CachyOS kernel. This way you can keep the official kernel as a backup in case an update goes wrong and you need to temporarily switch to the official kernel.


### PR DESCRIPTION
The current instructions in the README for keeping the CachyOS kernel as the default kernel after updates to the official Fedora kernel are no longer working in Fedora 44 as the official kernel makes itself default using a %post script, which runs after `kernel/postinst.d` scripts. Thank you @Hekel1989 for figuring it out!

By using a [DNF5 post_transaction action](https://dnf5.readthedocs.io/en/latest/libdnf5_plugins/actions.8.html) we can run the command after the %post script.

Fixes #94

Should there be instructions for removing the previous `postinst.d/99-default` script?

[Preview](https://github.com/CachyOS/copr-linux-cachyos/blob/94bc9b047e47773a4c7712e2a4b706db6f8d25c5/README.md#default-kernel)

---

### Default Kernel
By default Fedora will use the kernel that was most recently updated by `dnf` which will lead to inconsistent behaviour if you have multiple kernels installed, but we can tell Fedora to always boot with the latest CachyOS kernel by running a command after all kernel updates.

```sh
# Install the DNF5 actions plugin
sudo dnf install libdnf5-plugin-actions

# Create the actions directory
sudo mkdir -p /etc/dnf/libdnf5-plugins/actions.d

# Create the post_transaction action for kernel* packages
sudo tee /etc/dnf/libdnf5-plugins/actions.d/cachy-default.actions << 'EOF'
# After installing any kernel* package, set the latest CachyOS kernel as the default boot entry
post_transaction:kernel*:in::/usr/bin/sh -c /usr/bin/grubby\ --set-default=/boot/$(ls\ /boot\ |\ grep\ vmlinuz.*cachy\ |\ sort\ -V\ |\ tail\ -1)
EOF
```

The next time any installed kernel (e.g. the official Fedora kernel) gets an update, the system will change default kernel back to the latest CachyOS kernel. This way you can keep the official kernel as a backup in case an update goes wrong and you need to temporarily switch to the official kernel.
