### PR TITLE
Adding systemd-resolved dependency to cachyos-settings

### DIFF
--- a/sources/cachyos-settings/cachyos-settings.spec
+++ b/sources/cachyos-settings/cachyos-settings.spec
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
 
 Requires:       zram-generator
 Requires:       lua-luv
+Requires:       systemd-resolved
 Provides:       zram-generator-defaults
 Provides:       kerver
 Conflicts:      zram-generator-defaults


### PR DESCRIPTION
Should address (for now, if there isn't a better solution) https://github.com/CachyOS/CachyOS-Settings/issues/232 by making systemd-resolved a dependency of cachyos-settings