### PR TITLE
kernel: skip kernel-install in image builds (no running systemd)

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -357,7 +357,14 @@ Recommends:     linux-firmware
 
 %posttrans core
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
-    if [ ! -e /run/ostree-booted ]; then
+    # Also skip in image builds (bootc-image-builder / buildah / plain
+    # container chroots): /run/ostree-booted only exists on a BOOTED ostree
+    # system, so it does not guard image builds, and kernel-install's grub2
+    # plugins then fail there with grub2-probe/grub2-editenv errors and a
+    # non-zero %posttrans (issue #96). /run/systemd/system exists on any
+    # systemd-booted host and is bind-mounted into anaconda's install chroot,
+    # but is absent in build containers.
+    if [ ! -e /run/ostree-booted ] && [ -d /run/systemd/system ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
         if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
             cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"

--- a/sources/kernel-cachyos/kernel-cachyos-server.spec
+++ b/sources/kernel-cachyos/kernel-cachyos-server.spec
@@ -357,7 +357,14 @@ Recommends:     linux-firmware
 
 %posttrans core
     rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{_kver}
-    if [ ! -e /run/ostree-booted ]; then
+    # Also skip in image builds (bootc-image-builder / buildah / plain
+    # container chroots): /run/ostree-booted only exists on a BOOTED ostree
+    # system, so it does not guard image builds, and kernel-install's grub2
+    # plugins then fail there with grub2-probe/grub2-editenv errors and a
+    # non-zero %posttrans (issue #96). /run/systemd/system exists on any
+    # systemd-booted host and is bind-mounted into anaconda's install chroot,
+    # but is absent in build containers.
+    if [ ! -e /run/ostree-booted ] && [ -d /run/systemd/system ]; then
         /bin/kernel-install add %{_kver} %{_kernel_dir}/vmlinuz || exit $?
         if [[ ! -e "/boot/symvers-%{_kver}.zst" ]]; then
             cp "%{_kernel_dir}/symvers.zst" "/boot/symvers-%{_kver}.zst"


### PR DESCRIPTION
Follow-up to #96, as discussed with @mikaeldui ("sure!").

## Problem
`/run/ostree-booted` only exists on a **booted** ostree system, so the existing `%posttrans core` guard doesn't cover **image builds** (bootc-image-builder, buildah, plain container chroots — how Fedora-atomic derivatives consume this kernel). There `kernel-install add` still runs and its grub2 plugins fail:

```
grub2-probe: error: failed to get canonical path of 'overlay'.
grub2-editenv: ... not booted with systemd as init system (PID 1)
```

with a non-zero `%posttrans` exit. I hit this on every Margine OS build.

## Fix
Widen the guard: `[ ! -e /run/ostree-booted ] && [ -d /run/systemd/system ]`.
- `/run/systemd/system` exists on any systemd-booted host → normal installs unaffected;
- anaconda bind-mounts `/run` into the install chroot → classic kickstart installs still generate their BLS entries;
- absent in build containers → the noisy, pointless `kernel-install` is skipped exactly there.

Applied identically to both spec variants (bore + server).

## How to verify
```
# Containerfile
FROM ghcr.io/ublue-os/bluefin-dx:stable
RUN dnf -y copr enable bieszczaders/kernel-cachyos && dnf -y install kernel-cachyos-core
```
`podman build .` → with the current package the grub2-probe/grub2-editenv noise appears in `%posttrans`; with this patch it's gone. (@mikaeldui: your two earlier tests didn't actually exercise the patched RPM — your cachyfin recipe still installed the kernel from the bieszczaders COPR, and the margine-image fork died on an unrelated 404 (my build resolves a companion repo + signing secrets that don't exist in forks — my repo is a poor reproducer, sorry). The Containerfile above against your dnf.bolinder.uk repo is the minimal real test.)

Happy to iterate on the guard if you prefer a different detection.