### PR TITLE
fix: restore distinct RT kernel release namespace

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-rt.spec
@@ -71,7 +71,7 @@
 Name:           kernel-cachyos-rt%{?_lto_args:-lto}
 Summary:        Linux BORE %{?_lto_args:+ LTO }Cachy Sauce Kernel by CachyOS with other patches and improvements.
 Version:        %{_basekver}.%{_stablekver}
-Release:        cachyos1%{?_lto_args:.lto}%{?dist}
+Release:        cachyrt1%{?_lto_args:.lto}%{?dist}
 License:        GPL-2.0-only
 URL:            https://cachyos.org
 


### PR DESCRIPTION
### Root cause

The regular and RT specs both used `Release: cachyos1...`, while `_kver` is derived from `%{version}-%{release}`. As a result, regular and RT builds resolved the same kernel identity, including `_kver`, the `kernel-*-uname-r` Provides/Requires, `/lib/modules/%{_kver}`, and related devel and kernel-install paths. DNF could therefore select packages from both kernel families for the same uname namespace and then hit the file ownership conflicts reported in #110.

### Why this fix

Changing the RT release to `cachyrt1...` restores the repository's historical RT-specific release namespace; prior RT builds already used the `cachyrt` family, including `cachyrt1`, `cachyrt2`, and `cachyrt3`.

Regular remains `cachyos1`, server remains `cachyserver1`, and LTS remains `cachylts1`. RT-LTO is covered automatically by the same spec through `_lto_args`, becoming `cachyrt1.lto...`.

This separates RT from regular kernel filesystem and virtual capability namespaces without changing package family names or kernel configuration.

### Validation

- Regular, regular-LTO, RT, RT-LTO, server, and LTS resolve to distinct `_kver` namespaces after the change.
- RT internal Requires/Provides remain internally consistent, and RT and RT-LTO receive distinct `/lib/modules/...` paths.
- Repository-wide search found no consumer that requires RT to retain the `cachyos1` suffix.
- RPM EVR analysis confirms corrected `cachyrt1` sorts newer than the broken `cachyos1` RT release, including LTO variants; no Epoch or Version bump is required.
- No Obsoletes or Conflicts are added because they would interfere with normal install-only multi-kernel retention/coexistence semantics.
- `git diff --check` passes.

Native `rpmspec`, `rpmbuild`, and `rpmdev-vercmp` tools were not available locally, so no generated RPM metadata/SRPM validation was performed.

Fixes #110
